### PR TITLE
【バック】認証周りのGem導入

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -40,6 +40,18 @@ group :development, :test do
   gem "rubocop-rails-omakase", require: false
 end
 
+# クッキーのセキュリティ向上
+gem "rails_same_site_cookie"
+
+# 認証機能の基盤
+gem "devise"
+
+# トークン認証（トークンの方はRails7に対応していないので、githubから取得）
+gem 'devise_token_auth', '>= 1.2.0', git: "https://github.com/lynndylanhurley/devise_token_auth"
+
+# Deviseのメッセージを多言語対応させる
+gem "devise-i18n"
+
 gem "dotenv-rails", "3.1.7"
 gem "dockerfile-rails", ">= 1.6", :group => :development
 gem "dotenv", "3.1.7"

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/lynndylanhurley/devise_token_auth
+  revision: aedef3ca68d4e69bdc4a3e8987fa9d5f45420eec
+  specs:
+    devise_token_auth (1.2.5)
+      bcrypt (~> 3.0)
+      devise (> 3.5.2, < 5)
+      rails (>= 4.2.0, < 8.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -74,6 +83,7 @@ GEM
       tzinfo (~> 2.0, >= 2.0.5)
     ast (2.4.2)
     base64 (0.2.0)
+    bcrypt (3.1.20)
     benchmark (0.4.0)
     bigdecimal (3.1.9)
     bootsnap (1.18.4)
@@ -88,6 +98,14 @@ GEM
     debug (1.10.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    devise (4.9.4)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0)
+      responders
+      warden (~> 1.2.3)
+    devise-i18n (1.12.1)
+      devise (>= 4.9.0)
     dockerfile-rails (1.7.3)
       rails (>= 3.0.0)
     dotenv (3.1.7)
@@ -136,6 +154,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.2-x86_64-linux-gnu)
       racc (~> 1.4)
+    orm_adapter (0.5.0)
     parallel (1.26.3)
     parser (3.3.7.0)
       ast (~> 2.4.1)
@@ -181,6 +200,9 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails_same_site_cookie (0.1.10)
+      rack (>= 1.5)
+      user_agent_parser (~> 2.6)
     railties (7.2.2.1)
       actionpack (= 7.2.2.1)
       activesupport (= 7.2.2.1)
@@ -196,6 +218,9 @@ GEM
     regexp_parser (2.10.0)
     reline (0.6.0)
       io-console (~> 0.5)
+    responders (3.1.1)
+      actionpack (>= 5.2)
+      railties (>= 5.2)
     rubocop (1.71.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -234,7 +259,10 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    user_agent_parser (2.18.0)
     useragent (0.16.11)
+    warden (1.2.9)
+      rack (>= 2.0.9)
     websocket-driver (0.7.7)
       base64
       websocket-extensions (>= 0.1.0)
@@ -250,6 +278,9 @@ DEPENDENCIES
   bootsnap
   brakeman
   debug
+  devise
+  devise-i18n
+  devise_token_auth (>= 1.2.0)!
   dockerfile-rails (>= 1.6)
   dotenv (= 3.1.7)
   dotenv-rails (= 3.1.7)
@@ -257,6 +288,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rack-cors
   rails (~> 7.2.2, >= 7.2.2.1)
+  rails_same_site_cookie
   rubocop-rails-omakase
   tzinfo-data
 


### PR DESCRIPTION
## 概要
認証に必要なGemを導入しました。

## 実装内容
- [x] rails-same-site-cookie
- [x] rack-cros
        ⇨環境構築で実装済み
- [x] devise
- [x] devise-auth-token
- [x] devise-i18n

## issue
#15