### PR TITLE
新規登録のエラー修正

### DIFF
--- a/back/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/back/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,4 +1,5 @@
 class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+  skip_before_action :set_user, only: [:create]
   private
 
   def sign_up_params

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::API
-  before_action :set_user
+  before_action :set_user, except: [:create]
   include DeviseTokenAuth::Concerns::SetUserByToken
 
   private

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::API
-  before_action :set_user, except: [:create]
+  before_action :set_user
   include DeviseTokenAuth::Concerns::SetUserByToken
 
   private


### PR DESCRIPTION
## 概要
新規登録ができないエラーが以下の通り２つありましたので、修正しました。
・ヘルスチェックのコントローラーがなかったため疎通時にエラーが頻繁に出ていて他の疎通に影響が出ていた（ #96 で修正）
・ #96 で実装したset_userの処理が新規登録時にも処理してしまっていて、登録前に認証しようとしてしまいエラーが出ていた

## 実装内容
・set_userメソッドを新規登録時に処理しないように修正

## その他

## issue
#88 