### PR TITLE
【フロント・バック】投稿削除機能の実装

### DIFF
--- a/front/src/app/posts/page.tsx
+++ b/front/src/app/posts/page.tsx
@@ -1,15 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useAuth } from "@/contexts/AuthContext";
-import { FiMoreVertical, FiEdit } from "react-icons/fi";
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-} from "@/components/ui/dropdown-menu";
-import { Heart, ChevronRight } from "lucide-react"; // 検索機能実装時に追加
+import { ChevronRight } from "lucide-react"; // 検索機能実装時に追加
 import {
   Select,
   SelectContent,
@@ -17,88 +9,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import PostCard from "@/components/PostCard";
 import { getPosts } from "@/lib/axios";
 import { Post } from "@/lib/types";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import Link from "next/link";
 import Image from "next/image";
-import post_image_def from "/public/post_image_def.png";
 import posts_title from "/public/posts_title.png";
 import toast from "react-hot-toast";
-
-interface PostCardProps {
-  post: Post;
-}
-
-function PostCard({ post }: PostCardProps) {
-  const { user } = useAuth(); // 現在のユーザー情報を取得
-
-  return (
-    <div className="bg-white rounded-2xl shadow-sm overflow-hidden hover:shadow-md transition-shadow p-6">
-      <div className="flex items-center justify-end">
-        {user && user.id === post.user_id ? (
-          <DropdownMenu>
-            <DropdownMenuTrigger className="text-gray-500 hover:text-gray-600 transition-colors">
-              <FiMoreVertical className="w-6 h-6" />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent className="absolute -left-8 mt-1 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5">
-              <DropdownMenuItem>
-                <Link href={`/posts/${post.id}/edit`} className="flex items-center gap-2 text-gray-500">
-                  <FiEdit />
-                  編集する
-                </Link>
-              </DropdownMenuItem>
-              {/* <DropdownMenuItem onSelect={handleDelete} className="flex items-center gap-2 text-gray-500">
-                  <FiTrash />
-                  削除する
-                </DropdownMenuItem> */}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        ) : (
-          <div className="w-6 h-6" /> // 空のdivで幅を確保
-        )}
-      </div>
-      <div className="flex gap-3">
-        <div className="w-40 h-40 shrink-0">
-          <Image
-            src={post_image_def}
-            alt={post.title}
-            className="w-40 h-40 object-cover rounded-lg"
-          />
-        </div>
-        <div className="flex-1 min-w-0">
-          <h3 className="font-bold text-lg mb-2 line-clamp-2">{post.title}</h3>
-          <p className="text-sm text-gray-600 line-clamp-3 mb-2">
-            {post.description}
-          </p>
-          {/* <div className="flex flex-wrap gap-1 mb-2">
-            {post.tags && post.tags.map((tag, index) => (
-              <span
-                key={`${tag}-${index}`}
-                className="inline-block bg-gray-100 text-gray-800 text-xs px-2 py-1 rounded-full"
-              >
-                #{tag}
-              </span>
-            ))}
-          </div> */}
-        </div>
-      </div>
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <Avatar className="h-8 w-8">
-            <AvatarFallback className="bg-red-100 text-red-600 text-xs">
-              {post.user_id.toString().charAt(0).toUpperCase()}
-            </AvatarFallback>
-          </Avatar>
-          <span className="text-sm text-gray-500">ユーザー</span>
-        </div>
-        <button className="text-red-500 hover:text-red-600 transition-colors">
-          <Heart className="w-5 h-5" />
-        </button>
-      </div>
-    </div>
-  );
-}
 
 /** ランキング機能実装時に追加 **/
 function RankingSection() {
@@ -274,7 +192,10 @@ export default function PostsPage() {
                           key={post.id}
                           className="block"
                         >
-                          <PostCard post={post} />
+                          <PostCard
+                            post={post}
+                            setPosts={setPosts}
+                          />
                         </Link>
                       ))}
                     </div>

--- a/front/src/components/PostCard.tsx
+++ b/front/src/components/PostCard.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import React from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { FiMoreVertical, FiEdit, FiTrash } from "react-icons/fi";
+import { Heart } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Post } from "@/lib/types";
+import Image from "next/image";
+import Link from "next/link";
+import post_image_def from "/public/post_image_def.png";
+import { useDeletePost } from "@/hooks/useDeletePost";
+
+interface PostCardProps {
+  post: Post;
+  setPosts: React.Dispatch<React.SetStateAction<Post[]>>;
+}
+
+const PostCard: React.FC<PostCardProps> = ({ post, setPosts }) => {
+  const { user } = useAuth(); // 現在のユーザー情報を取得
+  const { handleDelete } = useDeletePost();
+
+  return (
+    <div className="bg-white rounded-2xl shadow-sm overflow-hidden hover:shadow-md transition-shadow p-6">
+      <div className="flex items-center justify-end">
+        {user && user.id === post.user_id ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger className="text-gray-500 hover:text-gray-600 transition-colors">
+              <FiMoreVertical className="w-6 h-6" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="absolute -left-8 mt-1 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5">
+              <DropdownMenuItem className="text-gray-500">
+                <Link
+                  href={`/posts/${post.id}/edit`}
+                  className="flex items-center gap-2"
+                >
+                  <FiEdit />
+                  編集する
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={() => handleDelete(post.id, post.title, setPosts)}
+                className="flex items-center gap-2 text-gray-500"
+              >
+                <FiTrash />
+                削除する
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : (
+          <div className="w-6 h-6" /> // 空のdivで幅を確保
+        )}
+      </div>
+      <div className="flex gap-3">
+        <div className="w-40 h-40 shrink-0">
+          <Image
+            src={post_image_def}
+            alt={post.title}
+            className="w-40 h-40 object-cover rounded-lg"
+          />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="font-bold text-lg mb-2 line-clamp-2">{post.title}</h3>
+          <p className="text-sm text-gray-600 line-clamp-3 mb-2">
+            {post.description}
+          </p>
+        </div>
+      </div>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Avatar className="h-8 w-8">
+            <AvatarFallback className="bg-red-100 text-red-600 text-xs">
+              {post.user_id.toString().charAt(0).toUpperCase()}
+            </AvatarFallback>
+          </Avatar>
+          <span className="text-sm text-gray-500">ユーザー</span>
+        </div>
+        <button className="text-red-500 hover:text-red-600 transition-colors">
+          <Heart className="w-5 h-5" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default PostCard;

--- a/front/src/hooks/useDeletePost.ts
+++ b/front/src/hooks/useDeletePost.ts
@@ -1,0 +1,35 @@
+import { useRouter, usePathname } from "next/navigation";
+import toast from "react-hot-toast";
+import { deletePost, getPosts } from "@/lib/axios";
+import { Post } from "@/lib/types";
+
+export const useDeletePost = () => {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const handleDelete = async (
+    postId: string,
+    postTitle: string,
+    setPosts: React.Dispatch<React.SetStateAction<Post[]>>
+  ) => {
+    if (window.confirm("" + postTitle + "を削除しますか？")) {
+      try {
+        // 投稿を削除
+        await deletePost(postId);
+        toast.success("" + postTitle + "が削除されました");
+
+      } catch (error) {
+        console.error("Error deleting or fetching posts:", error);
+        toast.error("投稿の削除に失敗しました");
+      }
+    }
+    // 投稿情報を再取得
+    const updatedPosts = await getPosts();
+    setPosts(updatedPosts);
+
+    // カレントページにリダイレクト
+    router.push(pathname);
+  };
+
+  return { handleDelete };
+};

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -3075,16 +3075,7 @@ streamsearch@^1.1.0:
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3170,14 +3161,7 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
## 概要
投稿を削除できるようにしました。
削除処理は、hooksにuseDeletePostを作成し、Importすることで削除できるようにしました。

## 実装内容
- [x] バックエンドで削除機能が正しく動作しているか確認
![image](https://github.com/user-attachments/assets/2dbc303a-0e97-48ce-a576-8f3eb17533bb)
- [x] 投稿のメニューに削除項目を追加
- [x] 「削除する」を選択した場合、削除をするかどうか選択するメッセージを追加
- [x] 削除メッセージにて「OK」を選択した場合、削除されることを確認
- [x] 削除メッセージにて「キャンセル」を選択した場合、削除されないことを確認
- [x] 削除後、カレントページにリダイレクトし、非同期でページが更新されるように実装

## その他
・投稿一覧ページのソースが肥大化していたので、PostCardコンポーネントを作成し、投稿カード関連のコードを移送しました。

・投稿編集ページにも削除ボタンを用意する予定でしたが、編集は編集機能のみと明確にするため、中止しました。

## issue
#50 
