### PR TITLE
【フロント】削除時の動作改善

### DIFF
--- a/front/src/components/PostCard.tsx
+++ b/front/src/components/PostCard.tsx
@@ -26,8 +26,21 @@ const PostCard: React.FC<PostCardProps> = ({ post, setPosts }) => {
   const { user } = useAuth(); // 現在のユーザー情報を取得
   const { handleDelete } = useDeletePost();
 
+  const handleDeleteClick = (event: React.MouseEvent) => {
+    event.preventDefault(); // 親の Link の遷移を防ぐ
+    event.stopPropagation(); // イベントの伝播を防ぐ
+    handleDelete(post.id, post.title, setPosts);
+  };
+
   return (
-    <div className="bg-white rounded-2xl shadow-sm overflow-hidden hover:shadow-md transition-shadow p-6">
+    <div
+      className="bg-white rounded-2xl shadow-sm overflow-hidden hover:shadow-md transition-shadow p-6"
+      onClick={(event) => {
+        if (event.target instanceof HTMLButtonElement) {
+          event.stopPropagation(); // ボタンをクリックしたときのみ遷移を防ぐ
+        }
+      }}
+    >
       <div className="flex items-center justify-end">
         {user && user.id === post.user_id ? (
           <DropdownMenu>
@@ -45,7 +58,7 @@ const PostCard: React.FC<PostCardProps> = ({ post, setPosts }) => {
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuItem
-                onSelect={() => handleDelete(post.id, post.title, setPosts)}
+                onClick={handleDeleteClick}
                 className="flex items-center gap-2 text-gray-500"
               >
                 <FiTrash />

--- a/front/src/hooks/useDeletePost.ts
+++ b/front/src/hooks/useDeletePost.ts
@@ -18,17 +18,17 @@ export const useDeletePost = () => {
         await deletePost(postId);
         toast.success("" + postTitle + "が削除されました");
 
+        // 投稿情報を再取得
+        const updatedPosts = await getPosts();
+        setPosts(updatedPosts);
+
+        // カレントページにリダイレクト
+        router.push(pathname);
       } catch (error) {
         console.error("Error deleting or fetching posts:", error);
         toast.error("投稿の削除に失敗しました");
       }
     }
-    // 投稿情報を再取得
-    const updatedPosts = await getPosts();
-    setPosts(updatedPosts);
-
-    // カレントページにリダイレクト
-    router.push(pathname);
   };
 
   return { handleDelete };


### PR DESCRIPTION
## 概要
削除機能で削除orキャンセルを選択した場合、投稿詳細ページに遷移してしまっていたので、改善時ました。

## 実装内容
- [x] PostCard全体が投稿詳細ページへのLinkでラップされていたので、削除の際はそのLinkを無視するように設定

## その他

## issue
#50 