### PR TITLE
【フロント・バック】未ログイン対応

### DIFF
--- a/back/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/back/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,5 +1,4 @@
 class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
-  skip_before_action :set_user, only: [:create]
   private
 
   def sign_up_params

--- a/back/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/back/app/controllers/api/v1/auth/sessions_controller.rb
@@ -1,5 +1,4 @@
 class Api::V1::Auth::SessionsController < DeviseTokenAuth::SessionsController
-  skip_before_action :set_user, only: [:create]
 
   def index
     if current_api_v1_user

--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -1,5 +1,4 @@
 class Api::V1::UsersController < ApplicationController
-  before_action :authenticate_api_v1_user! # ログインユーザーのみアクセス可能
 
   # ユーザー情報を取得
   def show

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -1,8 +1,16 @@
 class ApplicationController < ActionController::API
-  before_action :set_user
+  before_action :set_user_if_authenticated
   include DeviseTokenAuth::Concerns::SetUserByToken
 
   private
+
+  def set_user_if_authenticated
+    if current_api_v1_user
+      set_user
+    else
+      Rails.logger.info "ユーザーは認証されていません"
+    end
+  end
 
   def set_user
     @user = current_api_v1_user

--- a/front/src/app/create/page.tsx
+++ b/front/src/app/create/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { ImagePlus } from "lucide-react";
 import { createPost } from "@/lib/axios";
 import { useRouter } from "next/navigation";
+import { useAuth } from "@/contexts/AuthContext";
 import Link from "next/link";
 import Image from "next/image";
 import create_post_title from "/public/create_post_title.png";
@@ -27,6 +28,7 @@ export default function CreatePostPage() {
   const [typingText, setTypingText] = useState("");
   // const [imageUrl, setImageUrl] = useState(""); // 画像投稿機能実装時に追加（以降関連項目についてコメントアウト）
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const { isAuthenticated } = useAuth();
   const validCharacters = new Set([
     ...Object.keys(SMALL_KANA_MAP),
     ...Object.keys(BASIC_KANA_TO_ROMAN),
@@ -34,8 +36,15 @@ export default function CreatePostPage() {
     ...Object.keys(SPLIT_PATTERNS),
     ..."abcdefghijklmnopqrstuvwxyz",
     ..."ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-    ..."0123456789"
+    ..."0123456789",
   ]);
+
+  // 未ログインならエラーページへリダイレクト
+  useEffect(() => {
+    if (!isAuthenticated) {
+      router.push("/error");
+    }
+  }, [isAuthenticated, router]);
 
   const validateInput = (input: string) => {
     for (const char of input) {

--- a/front/src/app/error/page.tsx
+++ b/front/src/app/error/page.tsx
@@ -1,0 +1,22 @@
+
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+export default function ErrorPage() {
+  return (
+    <div className="min-h-screen w-full flex flex-col items-center justify-center bg-white px-4">
+      <div className="text-center">
+        <h1 className="text-[12rem] md:text-[16rem] font-bold text-gray-50 select-none relative">
+          <span className="absolute inset-0 text-gray-100">403</span>
+          403
+        </h1>
+        <p className="text-gray-600 text-lg md:text-xl mt-4 mb-8">
+          ログインしてください。
+        </p>
+        <Link href="/" passHref>
+         <Button>TOPに戻る</Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/front/src/app/posts/[id]/edit/page.tsx
+++ b/front/src/app/posts/[id]/edit/page.tsx
@@ -7,6 +7,8 @@ import { Button } from "@/components/ui/button";
 import { ImagePlus } from "lucide-react";
 import { getPost, updatePost } from "@/lib/axios";
 import { useParams } from "next/navigation";
+import { useAuth } from "@/contexts/AuthContext";
+import { useRouter } from "next/navigation";
 import {
   SMALL_KANA_MAP,
   BASIC_KANA_TO_ROMAN,
@@ -17,6 +19,7 @@ import Link from "next/link";
 import Image from "next/image";
 import edit_post_title from "/public/edit_post_title.png";
 import toast from "react-hot-toast";
+
 
 export default function EditPostPage() {
   const params = useParams(); // URLから投稿IDを取得
@@ -29,6 +32,8 @@ export default function EditPostPage() {
   // const [imageUrl, setImageUrl] = useState(""); // 画像投稿機能実装時に追加（以降関連項目についてコメントアウト）
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [loading, setLoading] = useState(true);
+  const { isAuthenticated } = useAuth();
+  const router = useRouter();
   const validCharacters = new Set([
     ...Object.keys(SMALL_KANA_MAP),
     ...Object.keys(BASIC_KANA_TO_ROMAN),
@@ -38,6 +43,13 @@ export default function EditPostPage() {
     ..."ABCDEFGHIJKLMNOPQRSTUVWXYZ",
     ..."0123456789"
   ]);
+
+  // 未ログインならエラーページへリダイレクト
+  useEffect(() => {
+    if (!isAuthenticated) {
+      router.push("/error");
+    }
+  }, [isAuthenticated, router]);
 
   const validateInput = (input: string) => {
     for (const char of input) {


### PR DESCRIPTION
## 概要
未ログインでも投稿一覧を表示し、タイピングゲームを遊べるようにしました。
また、未ログインで投稿ページと投稿編集ページを開こうとした場合、エラーページへ遷移するようにしました。

## 実装内容
- [ ] 未ログインでも投稿一覧を表示できるようにコントローラーを修正
- [ ] エラーページを追加
- [ ] 未ログインの場合、エラーページへ遷移するように実装

## その他

## issue
#107 
