### PR TITLE
【フロント・バック】マイページの実装

### DIFF
--- a/back/app/controllers/api/v1/typing_games_controller.rb
+++ b/back/app/controllers/api/v1/typing_games_controller.rb
@@ -1,0 +1,30 @@
+class Api::V1::TypingGamesController < ApplicationController
+  before_action :authenticate_api_v1_user!, only: [:create, :user_results]
+
+  def index
+    @typing_games = TypingGame.all
+    render json: @typing_games
+  end
+
+  def create
+    @typing_game = TypingGame.new(typing_game_params)
+    @typing_game.user = current_api_v1_user
+
+    if @typing_game.save
+      render json: @typing_game, status: :created
+    else
+      render json: @typing_game.errors, status: :unprocessable_entity
+    end
+  end
+
+  def user_results
+    @typing_games = current_api_v1_user.typing_games
+    render json: @typing_games
+  end
+
+  private
+
+  def typing_game_params
+    params.require(:typing_game).permit(:post_id, :play_time, :accuracy, :mistake_count, :score)
+  end
+end

--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -1,5 +1,6 @@
 class Post < ApplicationRecord
   belongs_to :user
+  has_many :typing_games, dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 40 }
   validates :description, length: { maximum: 500 }, allow_blank: true

--- a/back/app/models/typing_game.rb
+++ b/back/app/models/typing_game.rb
@@ -1,0 +1,8 @@
+class TypingGame < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+
+  validates :play_time, presence: true, numericality: { greater_than: 0 }
+  validates :accuracy, presence: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }
+  validates :mistake_count, presence: true, numericality: { greater_than_or_equal_to: 0 }
+end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ActiveRecord::Base
   include DeviseTokenAuth::Concerns::User
 
   has_many :posts, dependent: :destroy # ユーザーが削除されたら、関連する投稿も削除
+  has_many :typing_games, dependent: :destroy # # ユーザーが削除されたら、タイピング成績も削除
 
   # バリデーション
   validates :name, presence: true, uniqueness: true

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -15,7 +15,11 @@ Rails.application.routes.draw do
 
       resources :users, only: [:show] # ユーザー情報取得のエンドポイント
       resources :posts, only: [:index, :show, :create, :update, :destroy]
-
+      resources :typing_games, only: [:index, :create] do
+        collection do
+          get 'user_results', to: 'typing_games#user_results'
+        end
+      end
     end
   end
 

--- a/back/db/migrate/20250225131221_create_typing_games.rb
+++ b/back/db/migrate/20250225131221_create_typing_games.rb
@@ -1,0 +1,13 @@
+class CreateTypingGames < ActiveRecord::Migration[7.2]
+  def change
+    create_table :typing_games do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+      t.decimal :play_time, precision: 10, scale: 2, null: false
+      t.decimal :accuracy, precision: 5, scale: 2, null: false
+      t.integer :mistake_count, null: false, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_10_093736) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_25_131221) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +25,18 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_10_093736) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
+  create_table "typing_games", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.decimal "play_time", precision: 10, scale: 2, null: false
+    t.decimal "accuracy", precision: 5, scale: 2, null: false
+    t.integer "mistake_count", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_typing_games_on_post_id"
+    t.index ["user_id"], name: "index_typing_games_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -49,4 +61,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_10_093736) do
   end
 
   add_foreign_key "posts", "users"
+  add_foreign_key "typing_games", "posts"
+  add_foreign_key "typing_games", "users"
 end

--- a/back/test/fixtures/typing_games.yml
+++ b/back/test/fixtures/typing_games.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/back/test/models/typing_game_test.rb
+++ b/back/test/models/typing_game_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TypingGameTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/front/package.json
+++ b/front/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.5",
     "@radix-ui/react-select": "^2.1.6",
     "@radix-ui/react-slot": "^1.1.1",
+    "@radix-ui/react-tabs": "^1.1.3",
     "axios": "^1.7.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -70,3 +70,14 @@ body {
     @apply bg-background text-foreground;
   }
 }
+
+
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/front/src/app/mypage/likes-list.tsx
+++ b/front/src/app/mypage/likes-list.tsx
@@ -1,0 +1,7 @@
+export default function LikesList() {
+  return (
+    <div className="text-center py-8 text-muted-foreground">
+      いいね一覧（実装予定）
+    </div>
+  );
+}

--- a/front/src/app/mypage/page.tsx
+++ b/front/src/app/mypage/page.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { getUserTypingResults } from "@/lib/axios";
+import { useAuth } from "@/contexts/AuthContext";
+import { useRouter } from "next/navigation";
+import type { TypingResult } from "@/lib/types";
+import ResultsTable from "./results-table";
+// import UserProfile from "./user-profile" // プロフィール編集機能実装時に追加
+import PostsList from "./posts-list";
+import LikesList from "./likes-list";
+
+export default function MyPage() {
+  const { user, isAuthenticated } = useAuth();
+  const [results, setResults] = useState<TypingResult[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const router = useRouter();
+
+  // 未ログインならエラーページへリダイレクト
+  useEffect(() => {
+    if (!isAuthenticated) {
+      router.push("/error");
+    }
+  }, [isAuthenticated, router]);
+
+  useEffect(() => {
+    const fetchResults = async () => {
+      try {
+        const data = await getUserTypingResults();
+        setResults(data);
+      } catch (error) {
+        console.error("Failed to fetch typing results:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    if (user) {
+      fetchResults();
+    }
+  }, [user]);
+
+  return (
+    <div className="bg-[#f5f2ed]">
+      <div className="container max-w-4xl mx-auto px-4 py-8">
+        {/* ユーザー情報表示エリア */}
+        <div className="flex flex-col items-center text-center mb-8">
+          <div className="w-24 h-24 bg-gray-200 rounded-full flex items-center justify-center">
+            {/* プロフィール画像（実装予定） */}
+            <span className="text-gray-500">画像</span>
+          </div>
+          <h2 className="text-2xl font-bold mt-4">{user?.name}</h2>
+          <p className="mt-2 text-sm text-muted-foreground max-w-md">
+            {user?.bio || "自己紹介がありません"}
+          </p>
+
+          {/* ユーザーステータス情報 */}
+          {/* <div className="flex justify-center gap-4 mt-4">
+          <div className="text-center">
+            <p className="text-lg font-semibold">プレイ回数</p>
+            <p className="text-xl font-bold">xxxxx</p>
+          </div>
+          <div className="text-center">
+            <p className="text-lg font-semibold">1位獲得数</p>
+            <p className="text-xl font-bold">xxxxx</p>
+          </div>
+          <div className="text-center">
+            <p className="text-lg font-semibold">投稿数</p>
+            <p className="text-xl font-bold">xxxxx</p>
+          </div>
+        </div> */}
+        </div>
+
+        {/* タブナビゲーション */}
+        <Tabs defaultValue="posts" className="mt-8">
+          <TabsList className="w-full justify-start">
+            <TabsTrigger value="posts" className="flex-1">
+              投稿一覧
+            </TabsTrigger>
+            <TabsTrigger value="likes" className="flex-1">
+              いいね一覧
+            </TabsTrigger>
+            <TabsTrigger value="results" className="flex-1">
+              成績
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="posts" className="mt-6">
+            <PostsList />
+          </TabsContent>
+
+          <TabsContent value="likes" className="mt-6">
+            <LikesList />
+          </TabsContent>
+
+          <TabsContent value="results" className="mt-6">
+            <ResultsTable results={results} isLoading={isLoading} />
+          </TabsContent>
+        </Tabs>
+      </div>
+    </div>
+  );
+}

--- a/front/src/app/mypage/posts-list.tsx
+++ b/front/src/app/mypage/posts-list.tsx
@@ -1,0 +1,7 @@
+export default function PostsList() {
+  return (
+    <div className="text-center py-8 text-muted-foreground">
+      自分の投稿一覧（実装予定）
+    </div>
+  );
+}

--- a/front/src/app/mypage/results-table.tsx
+++ b/front/src/app/mypage/results-table.tsx
@@ -1,0 +1,215 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Button } from "@/components/ui/button"
+import { ChevronDown, ChevronUp, ChevronsUpDown, Loader2 } from "lucide-react"
+import type { TypingResult } from "@/lib/types"
+import { getPost } from "@/lib/axios"
+
+interface ResultsTableProps {
+  results: TypingResult[]
+  isLoading: boolean
+}
+
+type SortField = "play_time" | "accuracy" | "created_at"
+type SortOrder = "asc" | "desc"
+
+export default function ResultsTable({ results, isLoading }: ResultsTableProps) {
+  const [sortField, setSortField] = useState<SortField>("created_at")
+  const [sortOrder, setSortOrder] = useState<SortOrder>("desc")
+  const [currentPage, setCurrentPage] = useState(1)
+  const [postTitles, setPostTitles] = useState<Record<string, string>>({})
+  const itemsPerPage = 10
+
+  // 投稿タイトルを取得
+  useEffect(() => {
+    const fetchPostTitles = async () => {
+      const titles: Record<string, string> = {}
+
+      // 重複を排除して投稿IDのリストを作成
+      const postIds = [...new Set(results.map((result) => result.post_id))]
+
+      // 各投稿IDに対してタイトルを取得
+      for (const postId of postIds) {
+        try {
+          const post = await getPost(postId)
+          titles[postId] = post.title
+        } catch (error) {
+          console.error(`Failed to fetch post ${postId}:`, error)
+          titles[postId] = "削除された投稿"
+        }
+      }
+
+      setPostTitles(titles)
+    }
+
+    if (results.length > 0) {
+      fetchPostTitles()
+    }
+  }, [results])
+
+  const sortResults = (a: TypingResult, b: TypingResult) => {
+    if (sortField === "created_at") {
+      return sortOrder === "asc"
+        ? new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+        : new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    }
+    return sortOrder === "asc" ? a[sortField] - b[sortField] : b[sortField] - a[sortField]
+  }
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortOrder(sortOrder === "asc" ? "desc" : "asc")
+    } else {
+      setSortField(field)
+      setSortOrder("asc")
+    }
+  }
+
+  const getSortIcon = (field: SortField) => {
+    if (sortField !== field) return <ChevronsUpDown className="w-4 h-4" />
+    return sortOrder === "asc" ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />
+  }
+
+//   const getMedalIcon = (rank: number) => {
+//     if (rank === 1) {
+//       return (
+//         <div className="w-6 h-6 rounded-full bg-[#FFD700] flex items-center justify-center text-white font-bold">1</div>
+//       )
+//     }
+//     if (rank === 2) {
+//       return (
+//         <div className="w-6 h-6 rounded-full bg-[#C0C0C0] flex items-center justify-center text-white font-bold">2</div>
+//       )
+//     }
+//     if (rank === 3) {
+//       return (
+//         <div className="w-6 h-6 rounded-full bg-[#CD7F32] flex items-center justify-center text-white font-bold">3</div>
+//       )
+//     }
+//     return rank
+//   }
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString)
+    return date
+      .toLocaleDateString("ja-JP", {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      })
+      .replace(/\//g, "/")
+  }
+
+  const sortedResults = [...results].sort(sortResults)
+  const totalPages = Math.ceil(sortedResults.length / itemsPerPage)
+  const paginatedResults = sortedResults.slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage)
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="w-6 h-6 animate-spin" />
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="text-lg font-bold">タイトル</TableHead>
+              <TableHead>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleSort("play_time")}
+                  className="flex items-center gap-1 hover:bg-transparent"
+                >
+                  タイム
+                  {getSortIcon("play_time")}
+                </Button>
+              </TableHead>
+              {/* <TableHead>順位</TableHead> */}
+              <TableHead>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleSort("accuracy")}
+                  className="flex items-center gap-1 hover:bg-transparent"
+                >
+                  正確率
+                  {getSortIcon("accuracy")}
+                </Button>
+              </TableHead>
+              <TableHead>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleSort("created_at")}
+                  className="flex items-center gap-1 hover:bg-transparent"
+                >
+                  日付
+                  {getSortIcon("created_at")}
+                </Button>
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {paginatedResults.length > 0 ? (
+              paginatedResults.map((result) => (
+                <TableRow key={result.id}>
+                  <TableCell className="font-medium">{postTitles[result.post_id] || "読み込み中..."}</TableCell>
+                  <TableCell>{Number(result.play_time).toFixed(2)}秒</TableCell>
+                  {/* <TableCell>{getMedalIcon(index + 1)}</TableCell> */}
+                  <TableCell>{Number(result.accuracy).toFixed(1)}%</TableCell>
+                  <TableCell>{formatDate(result.created_at)}</TableCell>
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={5} className="text-center py-6 text-muted-foreground">
+                  タイピング結果がありません
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2 mt-4">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 1))}
+            disabled={currentPage === 1}
+          >
+            前へ
+          </Button>
+          {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
+            <Button
+              key={page}
+              variant={currentPage === page ? "default" : "outline"}
+              size="sm"
+              onClick={() => setCurrentPage(page)}
+            >
+              {page}
+            </Button>
+          ))}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setCurrentPage((prev) => Math.min(prev + 1, totalPages))}
+            disabled={currentPage === totalPages}
+          >
+            次へ
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/front/src/app/posts/[id]/page.tsx
+++ b/front/src/app/posts/[id]/page.tsx
@@ -152,6 +152,7 @@ export default function PostDetailPage() {
             <TypingGame
               displayText={post.display_text}
               typingText={post.typing_text}
+              postId={post.id}
             />
           )}
         </div>

--- a/front/src/components/Header.tsx
+++ b/front/src/components/Header.tsx
@@ -41,11 +41,13 @@ export function Header() {
                 <Link href="/create" passHref>
                   <Button>投稿する</Button>
                 </Link>
-                <Avatar className="h-12 w-12 border-white border-4 shadow-md">
-                  <AvatarFallback className="bg-[#FF8D76] text-white font-semibold shadow-md">
-                    {user ? getInitials(user.name) : "U"}
-                  </AvatarFallback>
-                </Avatar>
+                <Link href="/mypage" passHref>
+                  <Avatar className="h-12 w-12 border-white border-4 shadow-md">
+                    <AvatarFallback className="bg-[#FF8D76] text-white font-semibold shadow-md">
+                      {user ? getInitials(user.name) : "U"}
+                    </AvatarFallback>
+                  </Avatar>
+                </Link>
               </>
             ) : (
               <>

--- a/front/src/components/ui/hamburger-menu.tsx
+++ b/front/src/components/ui/hamburger-menu.tsx
@@ -50,9 +50,14 @@ export function HamburgerMenu() {
           <nav className="mt-4 space-y-4 text-gray-600">
             {isAuthenticated ? (
               <>
-                <a href="#" className="block px-4 py-2 text-lg hover:underline">
-                  マイページ
-                </a>
+                <Link href="/mypage" passHref className="block">
+                  <button
+                    onClick={() => setIsMenuOpen(false)}
+                    className="px-4 py-2 text-lg hover:underline"
+                  >
+                    マイページ
+                  </button>
+                </Link>
                 <button
                   onClick={handleLogout}
                   className="block w-full text-left px-4 py-2 text-lg hover:underline"

--- a/front/src/components/ui/table.tsx
+++ b/front/src/components/ui/table.tsx
@@ -1,0 +1,117 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+))
+Table.displayName = "Table"
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+))
+TableHeader.displayName = "TableHeader"
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+))
+TableBody.displayName = "TableBody"
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn(
+      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+      className
+    )}
+    {...props}
+  />
+))
+TableFooter.displayName = "TableFooter"
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+TableRow.displayName = "TableRow"
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      className
+    )}
+    {...props}
+  />
+))
+TableHead.displayName = "TableHead"
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    {...props}
+  />
+))
+TableCell.displayName = "TableCell"
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+TableCaption.displayName = "TableCaption"
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/front/src/components/ui/tabs.tsx
+++ b/front/src/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/front/src/lib/axios.ts
+++ b/front/src/lib/axios.ts
@@ -1,39 +1,53 @@
-import axios from 'axios';
-import Cookies from 'js-cookie';
-import { User, LoginResponse, RegisterParams, UpdateProfileParams, CreatePostParams, Post} from './types';
+import axios from "axios";
+import Cookies from "js-cookie";
+import {
+  User,
+  LoginResponse,
+  RegisterParams,
+  UpdateProfileParams,
+  CreatePostParams,
+  Post,
+  SaveTypingResultParams,
+  TypingResult,
+} from "./types";
 
 const api = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL,
   headers: {
-    'Content-Type': 'application/json',
+    "Content-Type": "application/json",
   },
   withCredentials: true,
 });
 
-console.log('NODE_ENV:', process.env.NODE_ENV);
+console.log("NODE_ENV:", process.env.NODE_ENV);
 
 // 環境判定ロジック
-const isProduction = process.env.NODE_ENV === 'production';
+const isProduction = process.env.NODE_ENV === "production";
 
 // DeviseTokenAuthのレスポンスヘッダーを保存
 const saveAuthHeaders = (headers: { [key: string]: string }) => {
   const authHeaders = {
-    'access-token': headers['access-token'],
-    'client': headers['client'],
-    'uid': headers['uid']
+    "access-token": headers["access-token"],
+    client: headers["client"],
+    uid: headers["uid"],
   };
   // js-cookieを使用してCookieを保存（30日間有効）
-  Cookies.set('auth', JSON.stringify(authHeaders), { secure: isProduction, sameSite: 'Lax', expires: 14, path: '/' });
+  Cookies.set("auth", JSON.stringify(authHeaders), {
+    secure: isProduction,
+    sameSite: "Lax",
+    expires: 14,
+    path: "/",
+  });
 };
 
 // 保存されたヘッダーをリクエストに追加
 api.interceptors.request.use((config) => {
-  const authCookie = Cookies.get('auth');
+  const authCookie = Cookies.get("auth");
   if (authCookie) {
     const headers = JSON.parse(authCookie);
     config.headers = {
       ...config.headers,
-      ...headers
+      ...headers,
     };
   }
   return config;
@@ -43,7 +57,7 @@ api.interceptors.request.use((config) => {
 export async function checkSession(): Promise<User | null> {
   try {
     console.log("セッション確認");
-    const response = await api.get('/auth/validate_token');
+    const response = await api.get("/auth/validate_token");
     console.log(response);
     return response.data.data;
   } catch {
@@ -52,8 +66,11 @@ export async function checkSession(): Promise<User | null> {
 }
 
 // ログイン
-export async function login(email: string, password: string): Promise<LoginResponse> {
-  const response = await api.post<LoginResponse>('/auth/sign_in', {
+export async function login(
+  email: string,
+  password: string
+): Promise<LoginResponse> {
+  const response = await api.post<LoginResponse>("/auth/sign_in", {
     email,
     password,
   });
@@ -63,7 +80,7 @@ export async function login(email: string, password: string): Promise<LoginRespo
 
 // 新規登録
 export async function register(params: RegisterParams): Promise<LoginResponse> {
-  const response = await api.post<LoginResponse>('/auth', {
+  const response = await api.post<LoginResponse>("/auth", {
     name: params.name,
     email: params.email,
     password: params.password,
@@ -74,29 +91,31 @@ export async function register(params: RegisterParams): Promise<LoginResponse> {
 }
 
 // プロフィール更新
-export async function updateProfile(params: UpdateProfileParams): Promise<void> {
-  const response = await api.put('/auth', {
+export async function updateProfile(
+  params: UpdateProfileParams
+): Promise<void> {
+  const response = await api.put("/auth", {
     name: params.name,
-    bio: params.bio
+    bio: params.bio,
   });
   saveAuthHeaders(response.headers as { [key: string]: string });
 }
 
 // ログアウト
 export async function logout(): Promise<void> {
-  await api.delete('/auth/sign_out');
-  Cookies.remove('auth', { path: '/' });
+  await api.delete("/auth/sign_out");
+  Cookies.remove("auth", { path: "/" });
 }
 
 // 投稿の作成
 export async function createPost(params: CreatePostParams): Promise<Post> {
-  const response = await api.post('/posts', params);
+  const response = await api.post("/posts", params);
   return response.data;
 }
 
 // 投稿一覧の取得
 export async function getPosts(): Promise<Post[]> {
-  const response = await api.get('/posts');
+  const response = await api.get("/posts");
   return response.data;
 }
 
@@ -107,7 +126,10 @@ export async function getPost(id: string): Promise<Post> {
 }
 
 // 投稿の更新
-export async function updatePost(id: string, params: Partial<CreatePostParams>): Promise<Post> {
+export async function updatePost(
+  id: string,
+  params: Partial<CreatePostParams>
+): Promise<Post> {
   const response = await api.put(`/posts/${id}`, params);
   return response.data;
 }
@@ -119,6 +141,27 @@ export async function deletePost(id: string): Promise<void> {
 
 // ユーザー情報の取得
 export async function getUser(id: string): Promise<User> {
-  const response = await api.get(`/users/${id}`)
-  return response.data
+  const response = await api.get(`/users/${id}`);
+  return response.data;
+}
+
+// タイピング結果の保存
+export async function saveTypingResult(
+  params: SaveTypingResultParams
+): Promise<TypingResult> {
+  const response = await api.post("/typing_games", {
+    typing_game: {
+      post_id: params.post_id,
+      play_time: params.play_time,
+      accuracy: params.accuracy,
+      mistake_count: params.mistake_count,
+    },
+  });
+  return response.data;
+}
+
+// ユーザーのタイピング結果履歴の取得
+export async function getUserTypingResults(): Promise<TypingResult[]> {
+  const response = await api.get("/typing_games");
+  return response.data;
 }

--- a/front/src/lib/axios.ts
+++ b/front/src/lib/axios.ts
@@ -162,6 +162,6 @@ export async function saveTypingResult(
 
 // ユーザーのタイピング結果履歴の取得
 export async function getUserTypingResults(): Promise<TypingResult[]> {
-  const response = await api.get("/typing_games");
+  const response = await api.get("/typing_games/user_results");
   return response.data;
 }

--- a/front/src/lib/types.ts
+++ b/front/src/lib/types.ts
@@ -52,3 +52,21 @@ export interface CreatePostParams {
   typing_text: string;
   // tags: string[]; // タグ機能実装時に追加
 }
+
+// タイピング結果の型定義
+export interface TypingResult {
+  id: string
+  user_id: string
+  post_id: string
+  play_time: number
+  accuracy: number
+  mistake_count: number
+  created_at: string
+}
+
+export interface SaveTypingResultParams {
+  post_id: string
+  play_time: number
+  accuracy: number
+  mistake_count: number
+}

--- a/front/src/lib/types.ts
+++ b/front/src/lib/types.ts
@@ -41,6 +41,7 @@ export interface Post {
   created_at: string;
   updated_at: string;
   // tags: string[]; // タグ機能実装時に追加
+  user?: User
 }
 
 // 投稿作成時のパラメータ
@@ -62,6 +63,7 @@ export interface TypingResult {
   accuracy: number
   mistake_count: number
   created_at: string
+  post?: Post
 }
 
 export interface SaveTypingResultParams {

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -633,6 +633,21 @@
     "@radix-ui/react-use-callback-ref" "1.1.0"
     "@radix-ui/react-use-controllable-state" "1.1.0"
 
+"@radix-ui/react-roving-focus@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.2.tgz#815d051a54299114a68db6eb8d34c41a3c0a646f"
+  integrity sha512-zgMQWkNO169GtGqRvYrzb0Zf8NhMHS2DuEB/TiEmVnpr5OqPU3i8lfbxaAmC2J/KYuIQxyoQQ6DxepyXp61/xw==
+  dependencies:
+    "@radix-ui/primitive" "1.1.1"
+    "@radix-ui/react-collection" "1.1.2"
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-context" "1.1.1"
+    "@radix-ui/react-direction" "1.1.0"
+    "@radix-ui/react-id" "1.1.0"
+    "@radix-ui/react-primitive" "2.0.2"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
+
 "@radix-ui/react-select@^2.1.6":
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-select/-/react-select-2.1.6.tgz#79c07cac4de0188e6f7afb2720a87a0405d88849"
@@ -673,6 +688,20 @@
   integrity sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.1"
+
+"@radix-ui/react-tabs@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tabs/-/react-tabs-1.1.3.tgz#c47c8202dc676dea47676215863d2ef9b141c17a"
+  integrity sha512-9mFyI30cuRDImbmFF6O2KUJdgEOsGh9Vmx9x/Dh9tOhL7BngmQPQfwW4aejKm5OHpfWIdmeV6ySyuxoOGjtNng==
+  dependencies:
+    "@radix-ui/primitive" "1.1.1"
+    "@radix-ui/react-context" "1.1.1"
+    "@radix-ui/react-direction" "1.1.0"
+    "@radix-ui/react-id" "1.1.0"
+    "@radix-ui/react-presence" "1.1.2"
+    "@radix-ui/react-primitive" "2.0.2"
+    "@radix-ui/react-roving-focus" "1.1.2"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
 
 "@radix-ui/react-use-callback-ref@1.1.0":
   version "1.1.0"
@@ -3075,7 +3104,16 @@ streamsearch@^1.1.0:
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3161,7 +3199,14 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
## 概要
マイページを実装しました。

## 実装内容
- [x] タイピング結果のリクエストを送信できるように実装
- [x] typing_gamesテーブルを作成
- [x] コントローラーおよびルーティングの設定
- [x] エンドポイントを作成して、フロント側で受け取れるように実装
- [x] マイページを作成
- [x] 各投稿のタイピング成績を一覧表示できるように実装
- [x] ヘッダーのアイコンおよびメニューからマイページへ遷移できるように実装
- [x] 未ログインでマイページを開こうとした場合、エラーページに遷移するように実装

## その他
投稿一覧、いいね一覧は本リリースで実装予定
UIは上記機能実装時に調整

## issue
#37 
#54 