### PR TITLE
【フロント】問題文の文字数制限の表示を修正

### DIFF
--- a/front/src/app/create/page.tsx
+++ b/front/src/app/create/page.tsx
@@ -172,7 +172,7 @@ export default function CreatePostPage() {
             <div className="space-y-2">
               <div className="flex items-center gap-2">
                 <label className="block text-lg font-bold">問題文</label>
-                <span className="text-xs text-gray-500">(500文字以内)</span>
+                <span className="text-xs text-gray-500">(50文字以内)</span>
               </div>
               <div className="flex items-center gap-2 text-gray-500 pt-2">
                 <label className="block text-sm font-medium">・表示文</label>


### PR DESCRIPTION
## 概要
投稿作成画面の問題文の文字数制限の表示が「500文字以内」となっていたので50文字以内に修正しました。

## 実装内容
- [x] 問題文の文字数制限の表記を修正

## その他

## issue
#112 