### PR TITLE
【フロント】プロフィール編集機能の実装

### DIFF
--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -17,16 +17,16 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body>
-          <div className="w-full min-h-screen max-w-8xl mx-auto flex flex-col mt-16">
-            <AuthProvider>
-              <Header />
-              <main className="flex-1">
-                {children}
-              </main>
-              <Footer />
-              <Toaster />
-            </AuthProvider>
-          </div>
+        <div className="w-full min-h-screen max-w-8xl mx-auto flex flex-col mt-16">
+          <AuthProvider>
+            <Header />
+            <main className="flex-1 bg-[#f5f2ed]">
+              {children}
+            </main>
+            <Footer />
+            <Toaster />
+          </AuthProvider>
+        </div>
       </body>
     </html>
   );

--- a/front/src/app/mypage/page.tsx
+++ b/front/src/app/mypage/page.tsx
@@ -7,6 +7,9 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useRouter } from "next/navigation";
 import type { TypingResult } from "@/lib/types";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { ProfileEditModal } from "@/components/ProfileEditModal";
+import Link from "next/link";
 
 import ResultsTable from "./results-table";
 // import UserProfile from "./user-profile" // プロフィール編集機能実装時に追加
@@ -15,6 +18,7 @@ import LikesList from "./likes-list";
 
 export default function MyPage() {
   const { user, isAuthenticated } = useAuth();
+  const [isProfileEditModalOpen, setIsProfileEditModalOpen] = useState(false);
   const [results, setResults] = useState<TypingResult[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const router = useRouter();
@@ -50,7 +54,27 @@ export default function MyPage() {
 
   return (
     <div className="bg-[#f5f2ed]">
-      <div className="container max-w-4xl mx-auto px-4 py-8">
+      <div className="container max-w-4xl mx-auto px-4 py-10">
+        {/* Breadcrumb */}
+        <div className="flex justify-between">
+          <div className="flex items-center gap-2 text-sm">
+            <Link href="/" className="text-blue-500 hover:underline">
+              TOP
+            </Link>
+            <span className="text-gray-500">&gt;</span>
+            <span className="text-gray-500">マイページ</span>
+          </div>
+          <div className="flex">
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full max-w-xs text-md"
+              onClick={() => setIsProfileEditModalOpen(true)}
+            >
+              プロフィール編集
+            </Button>
+          </div>
+        </div>
         {/* ユーザー情報表示エリア */}
         <div className="flex flex-col items-center text-center justify-center mb-8">
           <Avatar className="h-32 w-32 border-white border-4 shadow-md">
@@ -58,7 +82,7 @@ export default function MyPage() {
               {user ? getInitials(user.name) : "ND"}
             </AvatarFallback>
           </Avatar>
-          <h2 className="text-2xl font-bold mt-4">{user?.name}</h2>
+          <h2 className="text-3xl font-bold mt-4">{user?.name}</h2>
           <p className="mt-2 text-sm text-muted-foreground max-w-md">
             {user?.bio || "自己紹介がありません"}
           </p>
@@ -107,6 +131,10 @@ export default function MyPage() {
           </TabsContent>
         </Tabs>
       </div>
+      <ProfileEditModal
+        isOpen={isProfileEditModalOpen}
+        onClose={() => setIsProfileEditModalOpen(false)}
+      />
     </div>
   );
 }

--- a/front/src/app/mypage/results-table.tsx
+++ b/front/src/app/mypage/results-table.tsx
@@ -126,7 +126,7 @@ export default function ResultsTable({ results, isLoading }: ResultsTableProps) 
                   variant="ghost"
                   size="sm"
                   onClick={() => handleSort("play_time")}
-                  className="flex items-center gap-1 hover:bg-transparent"
+                  className="flex items-center gap-1 hover:bg-transparent border-none shadow-none"
                 >
                   タイム
                   {getSortIcon("play_time")}
@@ -138,7 +138,7 @@ export default function ResultsTable({ results, isLoading }: ResultsTableProps) 
                   variant="ghost"
                   size="sm"
                   onClick={() => handleSort("accuracy")}
-                  className="flex items-center gap-1 hover:bg-transparent"
+                  className="flex items-center gap-1 hover:bg-transparent border-none shadow-none"
                 >
                   正確率
                   {getSortIcon("accuracy")}
@@ -149,7 +149,7 @@ export default function ResultsTable({ results, isLoading }: ResultsTableProps) 
                   variant="ghost"
                   size="sm"
                   onClick={() => handleSort("created_at")}
-                  className="flex items-center gap-1 hover:bg-transparent"
+                  className="flex items-center gap-1 hover:bg-transparent border-none shadow-none"
                 >
                   日付
                   {getSortIcon("created_at")}

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -9,10 +9,10 @@ export default function Home() {
         src={hero_bg_image}
         alt="背景画像"
         layout="fill"
-        className="-z-10"
+        className="z-0"
         priority
       />
-      <div className="text-center mb-16">
+      <div className="text-center mb-16 relative z-10">
         <div className="inline-block rounded-full mb-8">
           <Image
             src={ninda_hero_logo}

--- a/front/src/components/ProfileEditModal.tsx
+++ b/front/src/components/ProfileEditModal.tsx
@@ -41,7 +41,7 @@ export function ProfileEditModal({ isOpen, onClose }: ProfileEditModalProps) {
       setUser((prev) => (prev ? { ...prev, name, bio } : null));
       toast.success("プロフィールを更新しました");
       onClose();
-    } catch (error) {
+    } catch {
       toast.error("プロフィールの更新に失敗しました");
     } finally {
       setIsLoading(false);

--- a/front/src/components/ProfileEditModal.tsx
+++ b/front/src/components/ProfileEditModal.tsx
@@ -1,0 +1,92 @@
+import { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { updateProfile } from "@/lib/axios";
+import { useAuth } from "@/contexts/AuthContext";
+import toast from "react-hot-toast";
+
+interface ProfileEditModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function ProfileEditModal({ isOpen, onClose }: ProfileEditModalProps) {
+  const { user, setUser } = useAuth();
+  const [name, setName] = useState(user?.name || "");
+  const [bio, setBio] = useState(user?.bio || "");
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (isOpen && user) {
+      setName(user.name || "");
+      setBio(user.bio || "");
+    }
+  }, [isOpen, user]);
+
+  const handleUpdateProfile = async () => {
+    if (!name.trim()) {
+      toast.error("表示名を入力してください");
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      await updateProfile({ name, bio });
+      setUser((prev) => (prev ? { ...prev, name, bio } : null));
+      toast.success("プロフィールを更新しました");
+      onClose();
+    } catch (error) {
+      toast.error("プロフィールの更新に失敗しました");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-[390px] h-auto">
+        <DialogHeader>
+          <DialogTitle className="text-center text-2xl font-bold">
+            プロフィール編集
+          </DialogTitle>
+        </DialogHeader>
+        <div className="space-y-6">
+          <div className="space-y-1">
+            <label className="text-sm font-medium">表示名</label>
+            <Input
+              type="text"
+              placeholder="表示名"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-medium">紹介文</label>
+            <textarea
+              className="w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-red-500"
+              placeholder="自己紹介"
+              value={bio}
+              onChange={(e) => setBio(e.target.value)}
+              rows={4}
+            />
+          </div>
+          <div className="flex justify-center">
+            <Button
+              className="w-52 bg-[#FF8D76] text-white hover:bg-red-500"
+              onClick={handleUpdateProfile}
+              disabled={isLoading}
+            >
+              {isLoading ? "更新中..." : "更新する"}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## 概要
プロフィール編集機能の実装をしました。

## 実装内容
- [x] マイページに「プロフィール編集」ボタンを配置
- [x] プロフィール編集モーダルを表示するコンポーネントを作成
- [x] プロフィール編集ボタンをクリックしたらモーダルを表示するように実装

## その他
更新処理は新規登録時に実装した「新規登録（プロフィール設定）」の処理を使用しました。
他、以下を追加・修正
・マイページにパンくずリストを追加しました
・マイページの成績欄のタイム、正確率、日付のボタンの枠を非表示にしました
・背景色が全域に反映されるように修正

## issue
#44 
#58 
