### PR TITLE
【フロント・バック】ユーザーページの作成

### DIFF
--- a/back/app/controllers/api/v1/typing_games_controller.rb
+++ b/back/app/controllers/api/v1/typing_games_controller.rb
@@ -22,6 +22,17 @@ class Api::V1::TypingGamesController < ApplicationController
     render json: @typing_games
   end
 
+  def typing_results
+    user = User.find_by(id: params[:id])
+
+    if user
+      typing_results = user.typing_games
+      render json: typing_results, status: :ok
+    else
+      render json: { error: "User not found" }, status: :not_found
+    end
+  end
+
   private
 
   def typing_game_params

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
       resources :typing_games, only: [:index, :create] do
         collection do
           get 'user_results', to: 'typing_games#user_results'
+          get 'typing_results', to: 'typing_games#typing_results'
         end
       end
     end

--- a/front/src/app/mypage/page.tsx
+++ b/front/src/app/mypage/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { getUserTypingResults } from "@/lib/axios";
+import { getCurrentUserTypingResults } from "@/lib/axios";
 import { useAuth } from "@/contexts/AuthContext";
 import { useRouter } from "next/navigation";
 import type { TypingResult } from "@/lib/types";
@@ -33,7 +33,7 @@ export default function MyPage() {
   useEffect(() => {
     const fetchResults = async () => {
       try {
-        const data = await getUserTypingResults();
+        const data = await getCurrentUserTypingResults();
         setResults(data);
       } catch (error) {
         console.error("Failed to fetch typing results:", error);
@@ -107,20 +107,16 @@ export default function MyPage() {
         {/* タブナビゲーション */}
         <Tabs defaultValue="posts" className="mt-8">
           <TabsList className="w-full justify-start">
-            <TabsTrigger value="results" className="flex-1">
-              成績
-            </TabsTrigger>
             <TabsTrigger value="posts" className="flex-1">
               投稿一覧
             </TabsTrigger>
             <TabsTrigger value="likes" className="flex-1">
               いいね一覧
             </TabsTrigger>
+            <TabsTrigger value="results" className="flex-1">
+              成績
+            </TabsTrigger>
           </TabsList>
-
-          <TabsContent value="results" className="mt-6">
-            <ResultsTable results={results} isLoading={isLoading} />
-          </TabsContent>
 
           <TabsContent value="posts" className="mt-6">
             <PostsList />
@@ -128,6 +124,10 @@ export default function MyPage() {
 
           <TabsContent value="likes" className="mt-6">
             <LikesList />
+          </TabsContent>
+
+          <TabsContent value="results" className="mt-6">
+            <ResultsTable results={results} isLoading={isLoading} />
           </TabsContent>
         </Tabs>
       </div>

--- a/front/src/app/users/[id]/page.tsx
+++ b/front/src/app/users/[id]/page.tsx
@@ -1,58 +1,58 @@
-"use client"
+"use client";
 
-import { useEffect, useState } from "react"
+import { useEffect, useState } from "react";
 // import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { getUser } from "@/lib/axios"
-import type { User } from "@/lib/types"
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import Link from "next/link"
-import { useParams } from "next/navigation"
+import { getUser } from "@/lib/axios";
+import type { User } from "@/lib/types";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import Link from "next/link";
+import { useParams } from "next/navigation";
 // import ResultsTable from "@/components/results-table"
 // import PostsList from "@/components/posts-list"
 // import LikesList from "@/components/likes-list"
 
 export default function UserPage() {
-  const params = useParams()
-  const userId: string = params.id as string
+  const params = useParams();
+  const userId: string = params.id as string;
 
-  const [profileUser, setProfileUser] = useState<User | null>(null)
-//   const [results, setResults] = useState<TypingResult[]>([])
-  const [isLoading, setIsLoading] = useState(true)
+  const [profileUser, setProfileUser] = useState<User | null>(null);
+  //   const [results, setResults] = useState<TypingResult[]>([])
+  const [isLoading, setIsLoading] = useState(true);
 
   // ユーザー情報の取得
   useEffect(() => {
     const fetchUserData = async () => {
       try {
-        setIsLoading(true)
-        const userData = await getUser(userId)
-        setProfileUser(userData)
+        setIsLoading(true);
+        const userData = await getUser(userId);
+        setProfileUser(userData);
 
         // // ユーザーのタイピング結果を取得
         // const resultsData = await getUserTypingResults(userId);
         // setResults(resultsData)
       } catch (error) {
-        console.error("Failed to fetch user data:", error)
+        console.error("Failed to fetch user data:", error);
       } finally {
-        setIsLoading(false)
+        setIsLoading(false);
       }
-    }
+    };
 
     if (userId) {
-      fetchUserData()
+      fetchUserData();
     }
-  }, [userId])
+  }, [userId]);
 
   // ユーザーのイニシャルを取得する関数
   const getInitials = (name: string) => {
-    return name?.substring(0, 2).toUpperCase() || "U"
-  }
+    return name?.substring(0, 2).toUpperCase() || "U";
+  };
 
   if (isLoading) {
     return (
       <div className="bg-[#f5f2ed] min-h-screen flex items-center justify-center">
         <div className="animate-pulse text-xl">ユーザー情報を読み込み中...</div>
       </div>
-    )
+    );
   }
 
   if (!profileUser) {
@@ -60,7 +60,7 @@ export default function UserPage() {
       <div className="bg-[#f5f2ed] min-h-screen flex items-center justify-center">
         <div className="text-xl">ユーザーが見つかりませんでした</div>
       </div>
-    )
+    );
   }
 
   return (
@@ -83,7 +83,10 @@ export default function UserPage() {
         <div className="flex flex-col items-center text-center justify-center mb-8">
           <Avatar className="h-32 w-32 border-white border-4 shadow-md">
             {profileUser.profile_image ? (
-              <AvatarImage src={profileUser.profile_image || "/placeholder.svg"} alt={profileUser.name} />
+              <AvatarImage
+                src={profileUser.profile_image || "/placeholder.svg"}
+                alt={profileUser.name}
+              />
             ) : (
               <AvatarFallback className="bg-[#FF8D76] text-white font-semibold shadow-md text-4xl">
                 {getInitials(profileUser.name)}
@@ -91,7 +94,9 @@ export default function UserPage() {
             )}
           </Avatar>
           <h2 className="text-3xl font-bold mt-4">{profileUser.name}</h2>
-          <p className="mt-2 text-sm text-muted-foreground max-w-md">{profileUser.bio || "自己紹介がありません"}</p>
+          <p className="mt-2 text-sm text-muted-foreground max-w-md">
+            {profileUser.bio || "自己紹介がありません"}
+          </p>
 
           {/* ユーザーステータス情報 */}
           {/* <div className="flex justify-center gap-8 mt-6">
@@ -138,5 +143,5 @@ export default function UserPage() {
         </Tabs> */}
       </div>
     </div>
-  )
+  );
 }

--- a/front/src/app/users/[id]/page.tsx
+++ b/front/src/app/users/[id]/page.tsx
@@ -1,0 +1,142 @@
+"use client"
+
+import { useEffect, useState } from "react"
+// import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { getUser } from "@/lib/axios"
+import type { User } from "@/lib/types"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import Link from "next/link"
+import { useParams } from "next/navigation"
+// import ResultsTable from "@/components/results-table"
+// import PostsList from "@/components/posts-list"
+// import LikesList from "@/components/likes-list"
+
+export default function UserPage() {
+  const params = useParams()
+  const userId: string = params.id as string
+
+  const [profileUser, setProfileUser] = useState<User | null>(null)
+//   const [results, setResults] = useState<TypingResult[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+
+  // ユーザー情報の取得
+  useEffect(() => {
+    const fetchUserData = async () => {
+      try {
+        setIsLoading(true)
+        const userData = await getUser(userId)
+        setProfileUser(userData)
+
+        // // ユーザーのタイピング結果を取得
+        // const resultsData = await getUserTypingResults(userId);
+        // setResults(resultsData)
+      } catch (error) {
+        console.error("Failed to fetch user data:", error)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    if (userId) {
+      fetchUserData()
+    }
+  }, [userId])
+
+  // ユーザーのイニシャルを取得する関数
+  const getInitials = (name: string) => {
+    return name?.substring(0, 2).toUpperCase() || "U"
+  }
+
+  if (isLoading) {
+    return (
+      <div className="bg-[#f5f2ed] min-h-screen flex items-center justify-center">
+        <div className="animate-pulse text-xl">ユーザー情報を読み込み中...</div>
+      </div>
+    )
+  }
+
+  if (!profileUser) {
+    return (
+      <div className="bg-[#f5f2ed] min-h-screen flex items-center justify-center">
+        <div className="text-xl">ユーザーが見つかりませんでした</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-[#f5f2ed]">
+      <div className="container max-w-4xl mx-auto px-4 py-10">
+        {/* Breadcrumb */}
+        <div className="flex items-center gap-2 text-sm mb-8">
+          <Link href="/" className="text-blue-500 hover:underline">
+            TOP
+          </Link>
+          <span className="text-gray-500">&gt;</span>
+          <Link href="/users" className="text-blue-500 hover:underline">
+            ユーザー一覧
+          </Link>
+          <span className="text-gray-500">&gt;</span>
+          <span className="text-gray-500">{profileUser.name}</span>
+        </div>
+
+        {/* ユーザー情報表示エリア */}
+        <div className="flex flex-col items-center text-center justify-center mb-8">
+          <Avatar className="h-32 w-32 border-white border-4 shadow-md">
+            {profileUser.profile_image ? (
+              <AvatarImage src={profileUser.profile_image || "/placeholder.svg"} alt={profileUser.name} />
+            ) : (
+              <AvatarFallback className="bg-[#FF8D76] text-white font-semibold shadow-md text-4xl">
+                {getInitials(profileUser.name)}
+              </AvatarFallback>
+            )}
+          </Avatar>
+          <h2 className="text-3xl font-bold mt-4">{profileUser.name}</h2>
+          <p className="mt-2 text-sm text-muted-foreground max-w-md">{profileUser.bio || "自己紹介がありません"}</p>
+
+          {/* ユーザーステータス情報 */}
+          {/* <div className="flex justify-center gap-8 mt-6">
+            <div className="text-center">
+              <p className="text-sm font-medium text-gray-500">プレイ回数</p>
+              <p className="text-xl font-bold">{profileUser.total_play_count}</p>
+            </div>
+            <div className="text-center">
+              <p className="text-sm font-medium text-gray-500">1位獲得数</p>
+              <p className="text-xl font-bold">0</p>
+            </div>
+            <div className="text-center">
+              <p className="text-sm font-medium text-gray-500">投稿数</p>
+              <p className="text-xl font-bold">{profileUser.posts_count}</p>
+            </div>
+          </div> */}
+        </div>
+
+        {/* タブナビゲーション */}
+        {/* <Tabs defaultValue="posts" className="mt-8">
+          <TabsList className="w-full justify-start">
+            <TabsTrigger value="posts" className="flex-1">
+              投稿一覧
+            </TabsTrigger>
+            <TabsTrigger value="likes" className="flex-1">
+              いいね一覧
+            </TabsTrigger>
+            <TabsTrigger value="results" className="flex-1">
+              成績
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="posts" className="mt-6">
+            <PostsList userId={userId} />
+          </TabsContent>
+
+          <TabsContent value="likes" className="mt-6">
+            <LikesList userId={userId} />
+          </TabsContent>
+
+          <TabsContent value="results" className="mt-6">
+            <ResultsTable results={results} isLoading={isLoading} />
+          </TabsContent>
+        </Tabs> */}
+      </div>
+    </div>
+  )
+}

--- a/front/src/lib/axios.ts
+++ b/front/src/lib/axios.ts
@@ -167,8 +167,14 @@ export async function saveTypingResult(
   return response.data;
 }
 
-// ユーザーのタイピング結果履歴の取得
-export async function getUserTypingResults(): Promise<TypingResult[]> {
+// カレントユーザーのタイピング結果履歴の取得
+export async function getCurrentUserTypingResults(): Promise<TypingResult[]> {
   const response = await api.get("/typing_games/user_results");
+  return response.data;
+}
+
+// ユーザーのタイピング結果履歴の取得
+export async function getUserTypingResults(id: string): Promise<TypingResult[]> {
+  const response = await api.get("/typing_games/typing_results${id}");
   return response.data;
 }

--- a/front/src/lib/axios.ts
+++ b/front/src/lib/axios.ts
@@ -175,6 +175,6 @@ export async function getCurrentUserTypingResults(): Promise<TypingResult[]> {
 
 // ユーザーのタイピング結果履歴の取得
 export async function getUserTypingResults(id: string): Promise<TypingResult[]> {
-  const response = await api.get("/typing_games/typing_results${id}");
+  const response = await api.get(`/typing_games/typing_results${id}`);
   return response.data;
 }


### PR DESCRIPTION
## 概要
ユーザーページを作成しました。

## 実装内容
- [ ] ユーザー一覧ページからユーザーカードをクリックするとユーザーページに遷移するように実装
- [ ] ユーザーページ（メイン）のみ実装

## その他
ユーザーページの成績の表示について少し実装を進めました。
実装部分についてはコメントアウトしています。

## issue
#38 
