### PR TITLE
【フロント・バック】ユーザーページ（投稿一覧）の作成

### DIFF
--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -13,4 +13,16 @@ class Api::V1::UsersController < ApplicationController
 
     render json: users, status: :ok
   end
+
+  def posts
+    puts "Requested User ID: #{params[:id]}" # ログ確認
+    user = User.find_by(id: params[:id])
+
+    if user
+      posts = user.posts.order(created_at: :desc) # 最新の投稿を先に表示
+      render json: posts, status: :ok
+    else
+      render json: { error: "User not found" }, status: :not_found
+    end
+  end
 end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -13,7 +13,10 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :users, only: [:show, :index] # ユーザー情報取得のエンドポイント
+      resources :users, only: [:show, :index] do # ユーザー情報取得のエンドポイント
+        member do
+          get 'posts', to: 'users#posts'
+        end      end
       resources :posts, only: [:index, :show, :create, :update, :destroy]
       resources :typing_games, only: [:index, :create] do
         collection do

--- a/front/src/app/posts/[id]/page.tsx
+++ b/front/src/app/posts/[id]/page.tsx
@@ -12,12 +12,13 @@ import { getPost, getUser } from "@/lib/axios";
 import type { Post, User } from "@/lib/types";
 import post_image_def from "/public/post_image_def.png";
 import toast from "react-hot-toast";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import TypingGame from "@/components/TypingGame";
 
 export default function PostDetailPage() {
   const { user } = useAuth(); // 現在のユーザー情報を取得
   const params = useParams(); // URLから投稿IDを取得
+  const router = useRouter(); // ルーター取得
   const id: string = params.id as string; // 明示的に `string` 型に変換
   const [post, setPost] = useState<Post | null>(null);
   const [loading, setLoading] = useState(true);
@@ -96,6 +97,17 @@ export default function PostDetailPage() {
     return postUser?.name || "ユーザー";
   };
 
+  // ユーザープロフィールへの遷移処理
+  const handleUserProfileClick = () => {
+    if (user && post.user_id === user.id) {
+      // 投稿者が現在のログインユーザーと同じ場合はマイページへ
+      router.push("/mypage");
+    } else {
+      // それ以外は通常のユーザーページへ
+      router.push(`/users/${post.user_id}`);
+    }
+  };
+
   return (
     <main className="min-h-screen bg-[#f5f7ef] sm:px-16 py-12">
       {/* Breadcrumb */}
@@ -158,10 +170,13 @@ export default function PostDetailPage() {
         </div>
         {/* User Info */}
         <div className="flex items-center justify-between mt-2">
-          <div className="flex items-center gap-3">
+          <div
+            className="flex items-center gap-3 cursor-pointer hover:opacity-80 transition-opacity"
+            onClick={handleUserProfileClick}
+          >
             <Avatar>
               <AvatarFallback className="bg-red-100 text-red-600">
-              {getUserInitial()}
+                {getUserInitial()}
               </AvatarFallback>
             </Avatar>
             <span className="text-gray-600">{getUserName()}</span>

--- a/front/src/app/users/[id]/page.tsx
+++ b/front/src/app/users/[id]/page.tsx
@@ -1,21 +1,21 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { getUserTypingResults, getUser } from "@/lib/axios";
 import type { TypingResult, User } from "@/lib/types";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import ResultsTable from "@/components/results-table"
-// import PostsList from "./posts-list"
+import ResultsTable from "@/components/results-table";
+import PostsList from "./posts-list";
 // import LikesList from "./likes-list"
 
 export default function UserPage() {
   const params = useParams();
   const userId: string = params.id as string;
   const [profileUser, setProfileUser] = useState<User | null>(null);
-  const [results, setResults] = useState<TypingResult[]>([])
+  const [results, setResults] = useState<TypingResult[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   // ユーザー情報の取得
@@ -28,7 +28,7 @@ export default function UserPage() {
 
         // ユーザーのタイピング結果を取得
         const resultsData = await getUserTypingResults(userId);
-        setResults(resultsData)
+        setResults(resultsData);
         console.log("リザルト結果", resultsData);
       } catch (error) {
         console.error("Failed to fetch user data:", error);
@@ -65,7 +65,7 @@ export default function UserPage() {
 
   return (
     <div className="bg-[#f5f2ed]">
-      <div className="container max-w-4xl mx-auto px-4 py-10">
+      <div className="container max-w-5xl mx-auto px-4 py-10">
         {/* Breadcrumb */}
         <div className="flex items-center gap-2 text-sm mb-8">
           <Link href="/" className="text-blue-500 hover:underline">
@@ -129,9 +129,9 @@ export default function UserPage() {
             </TabsTrigger>
           </TabsList>
 
-          {/* <TabsContent value="posts" className="mt-6">
+          <TabsContent value="posts" className="mt-6">
             <PostsList userId={userId} />
-          </TabsContent> */}
+          </TabsContent>
 
           {/* <TabsContent value="likes" className="mt-6">
             <LikesList userId={userId} />

--- a/front/src/app/users/[id]/posts-list.tsx
+++ b/front/src/app/users/[id]/posts-list.tsx
@@ -1,11 +1,114 @@
-// interface PostsListProps {
-//   userId: string;
-// }
+"use client";
 
-// export default function PostsList({ userId }: PostsListProps) {
-//   return (
-//     <div className="text-center py-8 text-muted-foreground">
-//       自分の投稿一覧（実装予定）
-//     </div>
-//   );
-// }
+import { useEffect, useState } from "react";
+import { getUserPosts } from "@/lib/axios";
+import type { Post } from "@/lib/types";
+import Link from "next/link";
+import PostCard from "@/components/PostCard";
+import { Button } from "@/components/ui/button";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+interface PostsListProps {
+  userId: string;
+}
+
+export default function PostsList({ userId }: PostsListProps) {
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [currentPage, setCurrentPage] = useState(1);
+  const postsPerPage = 10;
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      try {
+        setIsLoading(true);
+        const data = await getUserPosts(userId);
+        setPosts(data);
+      } catch (error) {
+        console.error("Failed to fetch user posts:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchPosts();
+  }, [userId]);
+
+  // ページネーション用の計算
+  const indexOfLastPost = currentPage * postsPerPage;
+  const indexOfFirstPost = indexOfLastPost - postsPerPage;
+  const currentPosts = posts.slice(indexOfFirstPost, indexOfLastPost);
+  const totalPages = Math.ceil(posts.length / postsPerPage);
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {[...Array(6)].map((_, index) => (
+          <div
+            key={index}
+            className="bg-gray-100 h-64 rounded-2xl animate-pulse"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (posts.length === 0) {
+    return (
+      <div className="text-center py-12 bg-white rounded-2xl">
+        <p className="text-gray-500">投稿がありません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-6">
+        {currentPosts.map((post) => (
+          <Link href={`/posts/${post.id}`} key={post.id} className="block">
+            <PostCard post={post} setPosts={setPosts} />
+          </Link>
+        ))}
+      </div>
+
+      {/* ページネーション */}
+      {totalPages > 1 && (
+        <div className="flex justify-center items-center gap-2 pt-8">
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 1))}
+            disabled={currentPage === 1}
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          {[...Array(totalPages)].map((_, index) => (
+            <Button
+              key={index + 1}
+              variant={currentPage === index + 1 ? "default" : "outline"}
+              size="sm"
+              className={
+                currentPage === index + 1
+                  ? "bg-[#FF8D76] hover:bg-orange-300"
+                  : ""
+              }
+              onClick={() => setCurrentPage(index + 1)}
+            >
+              {index + 1}
+            </Button>
+          ))}
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() =>
+              setCurrentPage((prev) => Math.min(prev + 1, totalPages))
+            }
+            disabled={currentPage === totalPages}
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/src/app/users/page.tsx
+++ b/front/src/app/users/page.tsx
@@ -18,6 +18,7 @@ import Link from "next/link";
 import Image from "next/image";
 import users_title from "/public/users_title.png";
 import toast from "react-hot-toast";
+import { useAuth } from "@/contexts/AuthContext"; // AuthContextをインポート
 
 /** ランキング機能実装時に追加 **/
 function RankingSection() {
@@ -84,6 +85,7 @@ export default function UsersPage() {
   const [sortBy, setSortBy] = useState("recent");
   const [currentPage, setCurrentPage] = useState(1);
   const usersPerPage = 8;
+  const { user: currentUser } = useAuth(); // 現在ログインしているユーザー情報を取得
 
   useEffect(() => {
     const fetchUsers = async () => {
@@ -129,6 +131,16 @@ export default function UsersPage() {
   const indexOfFirstUser = indexOfLastUser - usersPerPage;
   const currentUsers = sortedUsers.slice(indexOfFirstUser, indexOfLastUser);
   const totalPages = Math.ceil(sortedUsers.length / usersPerPage);
+
+  // ユーザーのリンク先を決定する関数
+  const getUserLink = (user: User) => {
+    // 現在のユーザーとリスト内のユーザーが同じ場合はマイページへ
+    if (currentUser && user.id === currentUser.id) {
+      return "/mypage";
+    }
+    // それ以外は通常のユーザーページへ
+    return `/users/${user.id}`;
+  };
 
   return (
     <>
@@ -192,7 +204,7 @@ export default function UsersPage() {
                     <div className="grid grid-col sm:grid-cols-1 lg:grid-cols-2 gap-4">
                       {currentUsers.map((user) => (
                         <Link
-                          href={`/users/${user.id}`}
+                          href={getUserLink(user)}
                           key={user.id}
                           className="block"
                         >

--- a/front/src/app/users/page.tsx
+++ b/front/src/app/users/page.tsx
@@ -106,7 +106,7 @@ export default function UsersPage() {
   const filteredUsers = users.filter(
     (user) =>
       user.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      user.bio?.toLowerCase().includes(searchQuery.toLowerCase()),
+      user.bio?.toLowerCase().includes(searchQuery.toLowerCase())
   );
 
   /** ソート機能実装時に追加 **/

--- a/front/src/components/PostCard.tsx
+++ b/front/src/components/PostCard.tsx
@@ -29,7 +29,7 @@ const PostCard: React.FC<PostCardProps> = ({ post, setPosts }) => {
   const { handleDelete } = useDeletePost();
   const [postUser, setPostUser] = useState<User | null>(null);
 
- // 投稿者の取得
+  // 投稿者の取得
   useEffect(() => {
     if (!post?.user_id) return;
 
@@ -61,6 +61,23 @@ const PostCard: React.FC<PostCardProps> = ({ post, setPosts }) => {
 
   const getUserName = () => {
     return postUser?.name;
+  };
+
+  // ユーザーのリンク先を決定する関数
+  const getUserProfileLink = () => {
+    // 投稿者が現在のログインユーザーと同じ場合はマイページへ
+    if (user && post.user_id === user.id) {
+      return "/mypage";
+    }
+    // それ以外は通常のユーザーページへ
+    return `/users/${post.user_id}`;
+  };
+
+  // ユーザープロフィール部分をクリックした時のハンドラ
+  const handleUserProfileClick = (event: React.MouseEvent) => {
+    event.preventDefault(); // 親のLinkの遷移を防ぐ
+    event.stopPropagation(); // イベントの伝播を防ぐ
+    window.location.href = getUserProfileLink(); // 直接URLを変更
   };
 
   return (
@@ -117,7 +134,10 @@ const PostCard: React.FC<PostCardProps> = ({ post, setPosts }) => {
         </div>
       </div>
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
+        <div
+          className="flex items-center gap-2 cursor-pointer hover:opacity-80 transition-opacity"
+          onClick={handleUserProfileClick}
+        >
           <Avatar className="h-8 w-8">
             <AvatarFallback className="bg-red-100 text-red-600 text-xs">
               {getUserInitial()}

--- a/front/src/lib/axios.ts
+++ b/front/src/lib/axios.ts
@@ -174,7 +174,15 @@ export async function getCurrentUserTypingResults(): Promise<TypingResult[]> {
 }
 
 // ユーザーのタイピング結果履歴の取得
-export async function getUserTypingResults(id: string): Promise<TypingResult[]> {
+export async function getUserTypingResults(
+  id: string
+): Promise<TypingResult[]> {
   const response = await api.get(`/typing_games/users/${id}/typing_results`);
+  return response.data;
+}
+
+// ユーザーの投稿を取得
+export async function getUserPosts(id: string): Promise<Post[]> {
+  const response = await api.get(`/users/${id}/posts`);
   return response.data;
 }


### PR DESCRIPTION
## 概要
ユーザーページに投稿一覧を表示できるようにしました。

## 実装内容
・バックエンド
- [x] 特定のユーザーの投稿を取得するメソッドを追加
- [x] ルートを設定

・フロントエンド
- [x] リクエストを追加
- [x] ユーザーページの投稿一覧を表示するように実装

## その他
他のページでユーザー名をクリックした場合、そのユーザーのページに遷移するようにしました。
また、ログインしているユーザーをクリックした場合は、マイページへ遷移するようにしました。

## issue
#49 