### PR TITLE
【フロント】ユーザーページ（成績欄）のランキングの作成

### DIFF
--- a/front/src/app/mypage/page.tsx
+++ b/front/src/app/mypage/page.tsx
@@ -55,7 +55,6 @@ export default function MyPage() {
           })
         );
         setResults(resultsWithRank);
-        console.log("自分のタイピング結果", resultsWithRank);
       } catch (error) {
         console.error("Failed to fetch typing results or ranking:", error);
       } finally {

--- a/front/src/components/Results-table.tsx
+++ b/front/src/components/Results-table.tsx
@@ -17,6 +17,7 @@ import Image from "next/image";
 import ranking_1_image from "/public/ranking_1_image.png";
 import ranking_2_image from "/public/ranking_2_image.png";
 import ranking_3_image from "/public/ranking_3_image.png";
+import { useRouter } from "next/navigation";
 
 interface ResultsTableProps {
   results: TypingResult[];
@@ -30,6 +31,7 @@ export default function ResultsTable({
   results,
   isLoading,
 }: ResultsTableProps) {
+  const router = useRouter();
   const [sortField, setSortField] = useState<SortField>("created_at");
   const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
   const [currentPage, setCurrentPage] = useState(1);
@@ -223,7 +225,11 @@ export default function ResultsTable({
             {displayResults.length > 0 ? (
               displayResults.map((result) => {
                 return (
-                  <TableRow key={result.id} className="hover:bg-gray-50">
+                  <TableRow
+                    key={result.id}
+                    className="hover:bg-gray-50 cursor-pointer" // クリック可能に
+                    onClick={() => router.push(`/posts/${result.post_id}`)} // 詳細ページへ遷移
+                  >
                     <TableCell className="font-medium text-left">
                       {postTitles[result.post_id] || "読み込み中..."}
                     </TableCell>


### PR DESCRIPTION
## 概要
ユーザーページにランキングを表示するようにしました。

## 実装内容
- [ ] 全体のランキングから、ユーザーがプレイした投稿のランキングを取得する処理を追加

## その他
成績欄で項目をクリックしたら、その項目の投稿詳細ページに遷移するようにしました。

## issue
#55 
#40 
