### PR TITLE
【バックエンド】ランキング重複の修正

### DIFF
--- a/back/app/controllers/api/v1/mypage_controller.rb
+++ b/back/app/controllers/api/v1/mypage_controller.rb
@@ -2,10 +2,13 @@ class Api::V1::MypageController < ApplicationController
   before_action :authenticate_api_v1_user!
 
   def typing_results
-    @typing_games = current_api_v1_user.typing_games
+    @typing_games = TypingGame
+      .select('DISTINCT ON (post_id) *')
+      .where(user_id: current_api_v1_user.id)
+      .order('post_id, accuracy DESC, play_time ASC')
+
     render json: @typing_games
   end
-
   def posts
     @posts = current_api_v1_user.posts.order(created_at: :desc)
     render json: @posts

--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -30,7 +30,11 @@ class Api::V1::UsersController < ApplicationController
     user = User.find_by(id: params[:id])
 
     if user
-      typing_results = user.typing_games
+      typing_results = TypingGame
+        .select('DISTINCT ON (post_id) *')
+        .where(user_id: user.id)
+        .order('post_id, accuracy DESC, play_time ASC')
+
       render json: typing_results, status: :ok
     else
       render json: { error: "User not found" }, status: :not_found


### PR DESCRIPTION
## 概要
ランキングに同じユーザーが重複して表示されるのを修正しました。

## 実装内容
- [x] 最も成績が良かったデータだけを取得するように、各コントローラーを修正
- [x] 投稿詳細ページ、マイページ、ユーザーページにて正しくランキングが表示されているか確認

## その他

## issue
#125 