### PR TITLE
【フロント・バック】タイピングゲームの実装（結果画面）の修正

### DIFF
--- a/back/app/controllers/api/v1/typing_games_controller.rb
+++ b/back/app/controllers/api/v1/typing_games_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::TypingGamesController < ApplicationController
       render json: { error: "post_id is required" }, status: :bad_request and return
     end
 
-    ranking_sql = <<-SQL
+    ranking_sql = ActiveRecord::Base.send(:sanitize_sql_array, [<<-SQL, post_id])
       SELECT
         ranked.post_id,
         ranked.user_id,
@@ -42,7 +42,7 @@ class Api::V1::TypingGamesController < ApplicationController
           tg.play_time
         FROM typing_games tg
         INNER JOIN users u ON u.id = tg.user_id
-        WHERE tg.post_id = #{ActiveRecord::Base.sanitize_sql(params[:post_id])}
+        WHERE tg.post_id = ?
         ORDER BY tg.user_id, tg.accuracy DESC, tg.play_time ASC
       ) AS ranked
       LIMIT 100
@@ -50,6 +50,63 @@ class Api::V1::TypingGamesController < ApplicationController
 
     records = ActiveRecord::Base.connection.exec_query(ranking_sql)
     render json: records.to_a, status: :ok
+  end
+
+  # プレイ後のランキング／プレイトータル人数を取得
+  def my_rank
+    typing_game_id = params[:typing_game_id]
+    unless typing_game_id.present?
+      render json: { error: "typing_game_id is required" }, status: :bad_request and return
+    end
+
+    game = TypingGame.find_by(id: typing_game_id)
+    unless game
+      render json: { error: "Typing game not found" }, status: :not_found and return
+    end
+
+    post_id = game.post_id
+    user_id = game.user_id
+
+    ranking_sql = <<-SQL
+      WITH ranked AS (
+        SELECT
+          tg.user_id,
+          tg.post_id,
+          MAX(tg.accuracy) AS accuracy,
+          MIN(tg.play_time) AS play_time
+        FROM typing_games tg
+        WHERE tg.post_id = $1
+        GROUP BY tg.user_id, tg.post_id
+      ),
+      ranked_with_order AS (
+        SELECT
+          *,
+          RANK() OVER (ORDER BY accuracy DESC, play_time ASC) AS rank
+        FROM ranked
+      )
+      SELECT
+        r.rank,
+        r.accuracy,
+        r.play_time,
+        (SELECT COUNT(*) FROM ranked) AS total_players
+      FROM ranked_with_order r
+      WHERE r.user_id = $2
+      LIMIT 1
+    SQL
+
+    records = ActiveRecord::Base.connection.exec_query(
+      ranking_sql,
+      "SQL for my_rank",
+      [[nil, post_id], [nil, user_id]]
+    )
+
+    record = records.first
+
+    if record
+      render json: record, status: :ok
+    else
+      render json: { error: "Ranking not found" }, status: :not_found
+    end
   end
 
   private

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
       resources :typing_games, only: [:index, :create] do
         collection do
           get 'ranking', to: 'typing_games#ranking'
+          get 'my_rank', to: 'typing_games#my_rank'
         end
       end
     end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
       resources :typing_games, only: [:index, :create] do
         collection do
           get 'ranking', to: 'typing_games#ranking'
-          get 'my_rank', to: 'typing_games#my_rank'
+          get 'pseudo_rank', to: 'typing_games#pseudo_rank'
         end
       end
     end

--- a/front/src/app/posts/[id]/page.tsx
+++ b/front/src/app/posts/[id]/page.tsx
@@ -91,16 +91,16 @@ export default function PostDetailPage() {
   }, [post?.user_id]);
 
   // ゲーム終了後にランキングを再取得する関数
-  // const refreshRanking = async () => {
-  //   if (!post_id) return;
+  const refreshRanking = async () => {
+    if (!post_id) return;
 
-  //   try {
-  //     const rankingData = await getRanking(Number(post_id));
-  //     setRanking(rankingData);
-  //   } catch (error) {
-  //     console.error("Error refreshing ranking:", error);
-  //   }
-  // };
+    try {
+      const rankingData = await getRanking(Number(post_id));
+      setRanking(rankingData);
+    } catch (error) {
+      console.error("Error refreshing ranking:", error);
+    }
+  };
 
   if (loading) {
     return (
@@ -254,7 +254,8 @@ export default function PostDetailPage() {
               displayText={post.display_text}
               typingText={post.typing_text}
               postId={post.id}
-              // onGameEnd={refreshRanking}
+              postTitle={post.title}
+              onGameEnd={refreshRanking}
             />
           )}
         </div>

--- a/front/src/components/LoginModal.tsx
+++ b/front/src/components/LoginModal.tsx
@@ -12,7 +12,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { LuMail, LuLock } from "react-icons/lu";
 import { login, register, updateProfile } from "@/lib/axios";
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from "@/contexts/AuthContext";
 import toast from "react-hot-toast";
 
 interface LoginModalProps {
@@ -212,7 +212,14 @@ export function LoginModal({ isOpen, onClose }: LoginModalProps) {
         </DialogHeader>
         <div className="space-y-6">
           {isLogin ? (
-            <>
+            <form
+              autoComplete="on"
+              onSubmit={(e) => {
+                e.preventDefault();
+                handleLogin();
+              }}
+              className="space-y-6"
+            >
               {/* ログイン画面 */}
               <div className="space-y-1">
                 <label className="text-sm font-medium">メールアドレス</label>
@@ -220,6 +227,8 @@ export function LoginModal({ isOpen, onClose }: LoginModalProps) {
                   <LuMail className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
                   <Input
                     type="email"
+                    name="email"
+                    autoComplete="email"
                     placeholder="ninda@example.com"
                     className="pl-10"
                     value={email}
@@ -241,6 +250,7 @@ export function LoginModal({ isOpen, onClose }: LoginModalProps) {
                 </div>
               </div>
               <Button
+                type="submit"
                 className="w-full bg-[#FF8D76] text-white hover:bg-red-500"
                 onClick={handleLogin}
                 disabled={isLoading}
@@ -280,66 +290,74 @@ export function LoginModal({ isOpen, onClose }: LoginModalProps) {
                   新規登録はこちらから
                 </a>
               </div>
-            </>
+            </form>
           ) : (
-            <>
-              <>
-                {/* 新規登録画面 */}
-                <div className="space-y-1">
-                  <label className="text-sm font-medium">メールアドレス</label>
-                  <div className="relative">
-                    <LuMail className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
-                    <Input
-                      type="email"
-                      placeholder="ninda@example.com"
-                      className="pl-10"
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
-                    />
-                  </div>
-                </div>
-                <div className="space-y-1">
-                  <label className="text-sm font-medium">パスワード</label>
-                  <div className="relative">
-                    <LuLock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
-                    <Input
-                      type="password"
-                      placeholder="半角英数字"
-                      className="pl-10"
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
-                    />
-                  </div>
-                </div>
-                <div className="space-y-1">
-                  <label className="text-sm font-medium">パスワード確認</label>
-                  <div className="relative">
-                    <LuLock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
-                    <Input
-                      type="password"
-                      placeholder="半角英数字"
-                      className="pl-10"
-                      value={passwordConfirmation}
-                      onChange={(e) => setPasswordConfirmation(e.target.value)}
-                    />
-                  </div>
-                </div>
-                <Button
-                  className="w-full bg-[#FF8D76] text-white hover:bg-red-500"
-                  onClick={handleRegister}
-                  disabled={isLoading}
-                >
-                  {isLoading ? "処理中..." : "登録する"}
-                </Button>
+            <form
+              autoComplete="on"
+              onSubmit={(e) => {
+                e.preventDefault();
+                handleRegister();
+              }}
+              className="space-y-6"
+            >
+              {" "}
+              {/* 新規登録画面 */}
+              <div className="space-y-1">
+                <label className="text-sm font-medium">メールアドレス</label>
                 <div className="relative">
-                  <div className="absolute inset-0 flex items-center">
-                    <span className="w-full border-t" />
-                  </div>
-                  <div className="relative flex justify-center text-xs uppercase">
-                    <span className="bg-white px-2 text-gray-500">または</span>
-                  </div>
+                  <LuMail className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+                  <Input
+                    type="email"
+                    placeholder="ninda@example.com"
+                    className="pl-10"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                  />
                 </div>
-                {/* <Button
+              </div>
+              <div className="space-y-1">
+                <label className="text-sm font-medium">パスワード</label>
+                <div className="relative">
+                  <LuLock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+                  <Input
+                    type="password"
+                    placeholder="半角英数字"
+                    className="pl-10"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                  />
+                </div>
+              </div>
+              <div className="space-y-1">
+                <label className="text-sm font-medium">パスワード確認</label>
+                <div className="relative">
+                  <LuLock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+                  <Input
+                    type="password"
+                    placeholder="半角英数字"
+                    className="pl-10"
+                    value={passwordConfirmation}
+                    onChange={(e) => setPasswordConfirmation(e.target.value)}
+                  />
+                </div>
+              </div>
+              <Button
+                type="submit"
+                className="w-full bg-[#FF8D76] text-white hover:bg-red-500"
+                onClick={handleRegister}
+                disabled={isLoading}
+              >
+                {isLoading ? "処理中..." : "登録する"}
+              </Button>
+              <div className="relative">
+                <div className="absolute inset-0 flex items-center">
+                  <span className="w-full border-t" />
+                </div>
+                <div className="relative flex justify-center text-xs uppercase">
+                  <span className="bg-white px-2 text-gray-500">または</span>
+                </div>
+              </div>
+              {/* <Button
                     variant="outline"
                     className="w-full border-2"
                   >
@@ -350,17 +368,16 @@ export function LoginModal({ isOpen, onClose }: LoginModalProps) {
                     />
                     Googleで登録
                   </Button> */}
-                <div className="text-center">
-                  <a
-                    href="#"
-                    className="text-sm text-blue-500 hover:underline"
-                    onClick={() => setIsLogin(true)} // ログイン画面に戻る
-                  >
-                    ログイン画面に戻る
-                  </a>
-                </div>
-              </>
-            </>
+              <div className="text-center">
+                <a
+                  href="#"
+                  className="text-sm text-blue-500 hover:underline"
+                  onClick={() => setIsLogin(true)} // ログイン画面に戻る
+                >
+                  ログイン画面に戻る
+                </a>
+              </div>
+            </form>
           )}
         </div>
       </DialogContent>

--- a/front/src/components/TypingGame.tsx
+++ b/front/src/components/TypingGame.tsx
@@ -7,6 +7,10 @@ import { Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { saveTypingResult, getPseudoRank } from "@/lib/axios";
 import { useAuth } from "@/contexts/AuthContext";
+import Image from "next/image";
+import ranking_1_image from "/public/ranking_1_image.png";
+import ranking_2_image from "/public/ranking_2_image.png";
+import ranking_3_image from "/public/ranking_3_image.png";
 
 type GameState = "waiting" | "loading" | "countdown" | "playing" | "finished";
 
@@ -14,6 +18,8 @@ interface TypingGameProps {
   displayText: string;
   typingText: string;
   postId?: string; // タイピングするテキストの投稿ID
+  postTitle?: string;
+  onGameEnd?: () => void;
 }
 
 interface GameResult {
@@ -27,6 +33,8 @@ export default function TypingGame({
   displayText,
   typingText,
   postId,
+  postTitle,
+  onGameEnd,
 }: TypingGameProps) {
   const [gameState, setGameState] = useState<GameState>("waiting");
   const [gameResult, setGameResult] = useState<GameResult>({
@@ -81,6 +89,11 @@ export default function TypingGame({
           rank: pseudoRank.rank,
           total: pseudoRank.total_players,
         });
+
+        // 終了後にランキングを再取得する
+        if (onGameEnd) {
+          onGameEnd();
+        }
       } catch (error) {
         console.error("ランキング取得に失敗しました", error);
       }
@@ -138,6 +151,44 @@ export default function TypingGame({
     };
   }, [gameState]);
 
+  // 順位アイコンを取得する関数
+  const getRankIcon = (rank: number) => {
+    if (rank === 1) {
+      return (
+        <Image
+          src={ranking_1_image}
+          alt="1位"
+          width={50}
+          height={50}
+          className="object-contain"
+        />
+      );
+    }
+    if (rank === 2) {
+      return (
+        <Image
+          src={ranking_2_image}
+          alt="2位"
+          width={50}
+          height={50}
+          className="object-contain"
+        />
+      );
+    }
+    if (rank === 3) {
+      return (
+        <Image
+          src={ranking_3_image}
+          alt="3位"
+          width={50}
+          height={50}
+          className="object-contain"
+        />
+      );
+    }
+    return <span className="text-4xl font-bold">{rank}</span>;
+  };
+
   return (
     <div className="flex items-center justify-center h-full w-full">
       {/* 待機画面 */}
@@ -193,39 +244,54 @@ export default function TypingGame({
 
       {/* 結果画面 */}
       {gameState === "finished" && (
-        <div className="text-center space-y-6">
-          <h2 className="text-2xl font-bold text-primary">ゲーム終了！</h2>
-          <div className="space-y-3">
-            <div className="text-4xl font-bold text-primary">
-              {gameResult.score}点
-            </div>
-            <div className="space-y-2 text-xl text-muted-foreground">
-              <div>タイム: {gameResult.time.toFixed(2)}秒</div>
-              <div>正確率: {gameResult.accuracy.toFixed(1)}%</div>
-              <div>ミスタイプ: {gameResult.mistakes}回</div>
+        <div className="bg-white rounded-3xl p-8 text-center space-y-6">
+          <h2 className="text-3xl font-bold text-black">{postTitle}の結果</h2>
+
+          {/* Time & Rank */}
+          <div className="flex justify-center gap-8 flex-wrap">
+            {/* Time カード */}
+            <div className="w-60 border rounded-xl p-4">
+              <div className="text-gray-500 text-sm mb-4">Time</div>
+              <div className="text-3xl font-bold text-primary text-[#fe6344]">
+                {gameResult.time.toFixed(2)}秒
+              </div>
             </div>
 
-            {ranking && (
-              <div className="mt-4 text-lg text-primary">
-                あなたの順位: <strong>{ranking.rank}</strong> 位 /{" "}
-                {ranking.total} 人中
+            {/* Rank カード */}
+            <div className="w-60 border rounded-xl p-4">
+              <div className="text-gray-500 text-sm mb-2">Rank</div>
+              <div className="text-3xl font-bold text-primary flex items-center justify-center gap-2 text-[#fe6344]">
+                {ranking?.rank != null ? getRankIcon(ranking.rank) : "-"}
+                <span className="text-black text-xl pt-2">
+                  位 / {ranking?.total ?? "-"}
+                </span>{" "}
               </div>
-            )}
-
-            {!isAuthenticated && (
-              <div className="text-center text-sm text-muted-foreground mt-4">
-                会員登録するとランキングに参加できるよ！
-              </div>
-            )}
+            </div>
           </div>
+
+          {/* 正誤率とミス */}
+          <div className="flex justify-center gap-6 text-gray-500 text-sm">
+            <div>正確率 {gameResult.accuracy.toFixed(1)}%</div>
+            <div>ミスタイプ数 {gameResult.mistakes}</div>
+          </div>
+
+          {/* 未ログイン時のメッセージ */}
+          {!isAuthenticated && (
+            <div className="text-black text-md mt-4 font-bold">
+              会員登録するとランキングに参加できるよ！
+            </div>
+          )}
+
+          {/* もう一度プレイ */}
           <Button
             onClick={() => {
               setGameState("waiting");
-              setCount(3); // カウントリセット
+              setCount(3);
               setGameResult({ score: 0, time: 0, mistakes: 0, accuracy: 0 });
-              setRanking(null); // ランキングリセット
+              setRanking(null);
             }}
             size="lg"
+            className="bg-[#FF8D76] text-white hover:bg-red-500"
           >
             もう一度プレイ
           </Button>

--- a/front/src/components/ui/input.tsx
+++ b/front/src/components/ui/input.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string; // インターフェースが空でなくなり、エラーが解消
 }
 

--- a/front/src/lib/axios.ts
+++ b/front/src/lib/axios.ts
@@ -9,6 +9,8 @@ import {
   Post,
   SaveTypingResultParams,
   TypingResult,
+  GetPseudoRankParams,
+  PseudoRankResult,
 } from "./types";
 
 const api = axios.create({
@@ -202,9 +204,15 @@ export async function getRanking(postId: number): Promise<TypingResult[]> {
 }
 
 // プレイ後のランキングの取得
-export async function getMyRank(typingGameId: string): Promise<TypingResult> {
-  const response = await api.get("/typing_games/my_rank", {
-    params: { typing_game_id: typingGameId },
+export async function getPseudoRank(
+  params: GetPseudoRankParams
+): Promise<PseudoRankResult> {
+  const response = await api.get("/typing_games/pseudo_rank", {
+    params: {
+      post_id: params.post_id,
+      play_time: params.play_time,
+      accuracy: params.accuracy,
+    },
   });
   return response.data;
 }

--- a/front/src/lib/axios.ts
+++ b/front/src/lib/axios.ts
@@ -200,3 +200,11 @@ export async function getRanking(postId: number): Promise<TypingResult[]> {
   });
   return response.data;
 }
+
+// プレイ後のランキングの取得
+export async function getMyRank(typingGameId: string): Promise<TypingResult> {
+  const response = await api.get("/typing_games/my_rank", {
+    params: { typing_game_id: typingGameId },
+  });
+  return response.data;
+}

--- a/front/src/lib/types.ts
+++ b/front/src/lib/types.ts
@@ -69,6 +69,7 @@ export interface TypingResult {
   post?: Post
   rank?: number;
   user_name?: string;
+  total_players?: number;
 }
 
 export interface SaveTypingResultParams {

--- a/front/src/lib/types.ts
+++ b/front/src/lib/types.ts
@@ -72,9 +72,23 @@ export interface TypingResult {
   total_players?: number;
 }
 
+// タイピング結果を保存するためのパラメータ
 export interface SaveTypingResultParams {
   post_id: string
   play_time: number
   accuracy: number
   mistake_count: number
+}
+
+// 擬似ランキングを取得するためのパラメータ
+export interface GetPseudoRankParams {
+  post_id: string
+  play_time: number
+  accuracy: number
+}
+
+// 擬似ランキングの型定義
+export interface PseudoRankResult {
+  rank: number;
+  total_players: number;
 }


### PR DESCRIPTION
## 概要
タイピングゲームプレイ後の結果画面のデザインの修正やランキングの表示、他微修正を行いました。

## 実装内容
バックエンド
- [ ] プレイ後の成績をもとに、擬似的にランキングを算出する処理を追加
- [ ] ゲストプレイヤーがプレイした場合は、擬似的にランキングを算出するが、ランキングの登録は行わない
- [ ] 投稿をプレイしたトータル人数を取得するロジックを追加
- [ ] プレイ結果によってトータル人数に含めるパターンと、含めないパターンを判断する処理を追加
- [ ] プレイした結果が過去の成績より優秀だった場合、成績をベストスコアとして更新し、ランキングに反映するように修正

フロントエンド
- [ ] バックエンドから擬似ランキングを取得する処理を実装
- [ ] 結果画面に擬似ランキングを表示する処理を実装
- [ ] 結果画面のデザインを修正
- [ ] ランキングの登録処理を非同期で反映するように修正

## その他
ログイン時に一度ログインしたユーザーのメールアドレスを再度ログインする際に候補として表示するように修正しました。

## issue
#29 
