### PR TITLE
【フロント】投稿削除機能の修正

### DIFF
--- a/front/src/app/mypage/page.tsx
+++ b/front/src/app/mypage/page.tsx
@@ -39,7 +39,8 @@ export default function MyPage() {
           typingResults.map(async (result) => {
             try {
               const ranking = await getRanking(Number(result.post_id)); // 各投稿の全体ランキングを取得
-              const myResult = ranking.findIndex((r) => r.user_id === result.user_id) + 1; // 自分の順位を取得
+              const myResult =
+                ranking.findIndex((r) => r.user_id === result.user_id) + 1; // 自分の順位を取得
               console.log("自分のランキング", myResult);
               return {
                 ...result,
@@ -139,7 +140,7 @@ export default function MyPage() {
           </TabsList>
 
           <TabsContent value="posts" className="mt-6">
-            {user && <PostsList userId={user.id} />}
+            <PostsList isMyPage />
           </TabsContent>
 
           <TabsContent value="likes" className="mt-6">

--- a/front/src/components/PostCard.tsx
+++ b/front/src/components/PostCard.tsx
@@ -22,9 +22,10 @@ import { getUser } from "@/lib/axios";
 interface PostCardProps {
   post: Post;
   setPosts: React.Dispatch<React.SetStateAction<Post[]>>;
+  isMyPage?: boolean;
 }
 
-const PostCard: React.FC<PostCardProps> = ({ post, setPosts }) => {
+const PostCard: React.FC<PostCardProps> = ({ post, setPosts, isMyPage }) => {
   const { user } = useAuth(); // 現在のユーザー情報を取得
   const { handleDelete } = useDeletePost();
   const [postUser, setPostUser] = useState<User | null>(null);
@@ -48,7 +49,7 @@ const PostCard: React.FC<PostCardProps> = ({ post, setPosts }) => {
   const handleDeleteClick = (event: React.MouseEvent) => {
     event.preventDefault(); // 親の Link の遷移を防ぐ
     event.stopPropagation(); // イベントの伝播を防ぐ
-    handleDelete(post.id, post.title, setPosts);
+    handleDelete(post.id, post.title, setPosts, isMyPage);
   };
 
   // ユーザー名の表示用関数

--- a/front/src/components/Posts-list.tsx
+++ b/front/src/components/Posts-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { getUserPosts } from "@/lib/axios";
+import { getCurrentUserPosts, getUserPosts } from "@/lib/axios";
 import type { Post } from "@/lib/types";
 import Link from "next/link";
 import PostCard from "@/components/PostCard";
@@ -9,10 +9,14 @@ import { Button } from "@/components/ui/button";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 
 interface PostsListProps {
-  userId: string;
+  userId?: string;
+  isMyPage?: boolean;
 }
 
-export default function PostsList({ userId }: PostsListProps) {
+export default function PostsList({
+  userId,
+  isMyPage = false,
+}: PostsListProps) {
   const [posts, setPosts] = useState<Post[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [currentPage, setCurrentPage] = useState(1);
@@ -22,7 +26,9 @@ export default function PostsList({ userId }: PostsListProps) {
     const fetchPosts = async () => {
       try {
         setIsLoading(true);
-        const data = await getUserPosts(userId);
+        const data = isMyPage
+          ? await getCurrentUserPosts() // マイページでは自分の投稿取得
+          : await getUserPosts(userId!); // ユーザーページでは指定ユーザーの投稿取得
         setPosts(data);
       } catch (error) {
         console.error("Failed to fetch user posts:", error);
@@ -32,7 +38,7 @@ export default function PostsList({ userId }: PostsListProps) {
     };
 
     fetchPosts();
-  }, [userId]);
+  }, [userId, isMyPage]);
 
   // ページネーション用の計算
   const indexOfLastPost = currentPage * postsPerPage;
@@ -66,7 +72,7 @@ export default function PostsList({ userId }: PostsListProps) {
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-6">
         {currentPosts.map((post) => (
           <Link href={`/posts/${post.id}`} key={post.id} className="block">
-            <PostCard post={post} setPosts={setPosts} />
+            <PostCard post={post} setPosts={setPosts} isMyPage={isMyPage} />
           </Link>
         ))}
       </div>

--- a/front/src/hooks/useDeletePost.ts
+++ b/front/src/hooks/useDeletePost.ts
@@ -1,6 +1,6 @@
 import { useRouter, usePathname } from "next/navigation";
 import toast from "react-hot-toast";
-import { deletePost, getPosts } from "@/lib/axios";
+import { deletePost, getPosts, getCurrentUserPosts } from "@/lib/axios";
 import { Post } from "@/lib/types";
 
 export const useDeletePost = () => {
@@ -10,7 +10,8 @@ export const useDeletePost = () => {
   const handleDelete = async (
     postId: string,
     postTitle: string,
-    setPosts: React.Dispatch<React.SetStateAction<Post[]>>
+    setPosts: React.Dispatch<React.SetStateAction<Post[]>>,
+    isMyPage: boolean = false
   ) => {
     if (window.confirm("" + postTitle + "を削除しますか？")) {
       try {
@@ -19,7 +20,9 @@ export const useDeletePost = () => {
         toast.success("" + postTitle + "が削除されました");
 
         // 投稿情報を再取得
-        const updatedPosts = await getPosts();
+        const updatedPosts = isMyPage
+          ? await getCurrentUserPosts()
+          : await getPosts();
         setPosts(updatedPosts);
 
         // カレントページにリダイレクト


### PR DESCRIPTION
## 概要
マイページで投稿を削除すると、全投稿が表示されてしまっていたので、
削除後もログイン中のユーザーの投稿のみ表示されるようにしました。

## 実装内容
- [x] マイページかどうかのフラグを持たせて、マイページから削除した場合は自身の投稿のみ再取得し、投稿一覧から削除した場合は、全投稿を再取得するようにしました。

## その他

## issue
#130 
