### PR TITLE
【バック・インフラ】本番環境の設定

### DIFF
--- a/back/config/initializers/carrierwave.rb
+++ b/back/config/initializers/carrierwave.rb
@@ -3,20 +3,15 @@ require "carrierwave/storage/file"
 require "carrierwave/storage/fog"
 
 CarrierWave.configure do |config|
-  if ENV["USE_S3"] == "true"
-    config.fog_provider = "fog/aws"
-    config.fog_credentials = {
-      provider: "AWS",
-      aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
-      aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
-      region: ENV["AWS_REGION"],
-      path_style: true
-    }
-    config.fog_directory = ENV["AWS_S3_BUCKET"]
-    config.fog_public = false
-    config.storage = :fog
-  else
-    config.storage = :file
-    config.enable_processing = !Rails.env.test? # テスト環境で加工を無効にする
-  end
+  config.fog_provider = "fog/aws"
+  config.fog_credentials = {
+    provider: "AWS",
+    aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+    aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
+    region: ENV["AWS_REGION"],
+    path_style: true
+  }
+  config.fog_directory = ENV["AWS_S3_BUCKET"]
+  config.fog_public = false
+  config.storage = :fog
 end


### PR DESCRIPTION
## 概要
本番環境（Fly.io）の環境変数の設定をしました。

## 実装内容
バックエンド
- [ ] 開発環境と本番環境でS3しか使用しないので、carrierwave.rbにて切り分けを削除
- [ ] 環境変数を修正

インフラ
- [ ] 本番環境用のIAMユーザーを作成
- [ ] 本番環境用のS3バケットを作成
- [ ] Fly.ioで環境変数を設定

## その他
本番環境の設定に伴い、carrierwave.rbを微修正しました。

## issue
#138 
