### PR TITLE
【バックエンド】Dockerfileの修正

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -59,6 +59,7 @@ RUN apt-get update -qq && \
         curl \
         postgresql-client \
         fonts-noto-cjk \
+        imagemagick \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives
 


### PR DESCRIPTION
## 概要
本番環境でImageMagickがインストールされておらず、画像アップロード時にエラーが出ていたため、ImageMagickをインストールするようにしました。

## 実装内容
- [x] Dockerfileの修正

## その他

## issue
#138 