### PR TITLE
【フロント】fix:画像の非同期（ランキング機能）

### DIFF
--- a/front/src/app/posts/[id]/page.tsx
+++ b/front/src/app/posts/[id]/page.tsx
@@ -121,6 +121,30 @@ export default function PostDetailPage() {
     try {
       const rankingData = await getRanking(Number(post_id));
       setRanking(rankingData);
+
+      // ランキングユーザーの情報を再取得
+      const userPromises = rankingData.map(async (result) => {
+        if (result.user_id && !rankingUsers[result.user_id]) {
+          try {
+            const userData = await getUser(result.user_id);
+            return { [result.user_id]: userData };
+          } catch (error) {
+            console.error(`Failed to fetch user ${result.user_id}:`, error);
+            return null;
+          }
+        }
+        return null;
+      });
+
+      const userResults = await Promise.all(userPromises);
+      const newUsers = userResults.reduce((acc, userObj) => {
+        if (userObj) {
+          return { ...acc, ...userObj };
+        }
+        return acc;
+      }, {});
+
+      setRankingUsers((prev) => ({ ...prev, ...newUsers }));
     } catch (error) {
       console.error("Error refreshing ranking:", error);
     }


### PR DESCRIPTION
## 概要
投稿詳細画面のランキング欄にタイピング終了後にランキングが非同期で反映されるが、画像が反映されていなかったので、反映されるように修正しました。

## 実装内容
- [ ] ランキング再取得のロジックにユーザー情報も取得するように修正

## その他

## issue
#135 