### PR TITLE
【フロント・バック】タイピング結果画面（ランキング）の修正

### DIFF
--- a/front/src/app/mypage/page.tsx
+++ b/front/src/app/mypage/page.tsx
@@ -28,9 +28,10 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import toast from "react-hot-toast";
+import { usePathname } from "next/navigation";
 
 export default function MyPage() {
-  const { user, isAuthenticated, setUser } = useAuth();
+  const { user, isAuthenticated, setUser, isLoggingOutRef } = useAuth();
   const [isProfileEditModalOpen, setIsProfileEditModalOpen] = useState(false);
   const [results, setResults] = useState<TypingResult[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -39,13 +40,18 @@ export default function MyPage() {
   const [isUploading, setIsUploading] = useState(false);
   const [activeTab, setActiveTab] = useState("posts");
   const router = useRouter();
+  const pathname = usePathname();
 
   // 未ログインならエラーページへリダイレクト
   useEffect(() => {
-    if (!isAuthenticated) {
+    if (
+      !isAuthenticated &&
+      pathname === "/mypage" &&
+      !isLoggingOutRef.current
+    ) {
       router.push("/error");
     }
-  }, [isAuthenticated, router]);
+  }, [isAuthenticated, pathname, router, isLoggingOutRef]);
 
   useEffect(() => {
     const fetchResults = async () => {

--- a/front/src/app/posts/[id]/page.tsx
+++ b/front/src/app/posts/[id]/page.tsx
@@ -120,7 +120,6 @@ export default function PostDetailPage() {
     if (!post_id) return;
     try {
       const rankingData = await getRanking(Number(post_id));
-      setRanking(rankingData);
 
       // ランキングユーザーの情報を再取得
       const userPromises = rankingData.map(async (result) => {
@@ -145,6 +144,7 @@ export default function PostDetailPage() {
       }, {});
 
       setRankingUsers((prev) => ({ ...prev, ...newUsers }));
+      setRanking(rankingData);
     } catch (error) {
       console.error("Error refreshing ranking:", error);
     }
@@ -216,10 +216,10 @@ export default function PostDetailPage() {
 
   // ランキング用のユーザー名取得関数
   const getRankingUserInitial = (userId?: string, userName?: string) => {
-    if (userName) {
+    if (userName && userName.length > 0) {
       return userName.substring(0, 2).toUpperCase();
     }
-    if (userId && rankingUsers[userId]) {
+    if (userId && rankingUsers[userId]?.name) {
       return rankingUsers[userId].name.substring(0, 2).toUpperCase();
     }
     return "U";
@@ -509,7 +509,7 @@ export default function PostDetailPage() {
                                 {getRankingUserInitial(
                                   result.user_id,
                                   result.user_name
-                                )}
+                                ) || "U"}
                               </AvatarFallback>
                             )}
                           </Avatar>

--- a/front/src/components/TypingGame.tsx
+++ b/front/src/components/TypingGame.tsx
@@ -68,6 +68,13 @@ export default function TypingGame({
     // ログインしている場合のみ結果を保存
     if (postId) {
       try {
+        // 保存せずに今回の成績からランキングを取得
+        const pseudoRank = await getPseudoRank({
+          post_id: postId,
+          play_time: finalTime,
+          accuracy: accuracy,
+        });
+
         if (isAuthenticated) {
           // タイピング結果を保存
           await saveTypingResult({
@@ -77,13 +84,6 @@ export default function TypingGame({
             mistake_count: totalMistakes,
           });
         }
-
-        // 保存せずに今回の成績からランキングを取得
-        const pseudoRank = await getPseudoRank({
-          post_id: postId,
-          play_time: finalTime,
-          accuracy: accuracy,
-        });
 
         setRanking({
           rank: pseudoRank.rank,

--- a/front/src/components/ui/hamburger-menu.tsx
+++ b/front/src/components/ui/hamburger-menu.tsx
@@ -14,11 +14,13 @@ import { useAuth } from "@/contexts/AuthContext";
 import { logout } from "@/lib/axios";
 import toast from "react-hot-toast";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 export function HamburgerMenu() {
   const [isLoginOpen, setIsLoginOpen] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const { isAuthenticated, setUser } = useAuth();
+  const { isAuthenticated, setUser, isLoggingOutRef } = useAuth();
+  const router = useRouter();
 
   const handleLoginClick = () => {
     setIsLoginOpen(true);
@@ -27,14 +29,20 @@ export function HamburgerMenu() {
 
   // ログアウト処理
   const handleLogout = async () => {
+    isLoggingOutRef.current = true;
+
+    // すぐにトップページにリダイレクト
+    router.replace("/");
     try {
       await logout();
       setUser(null);
       toast.success("ログアウトしました");
     } catch {
       toast.error("ログアウトに失敗しました");
+    } finally {
+      isLoggingOutRef.current = false;
+      setIsMenuOpen(false);
     }
-    setIsMenuOpen(false);
   };
 
   return (

--- a/front/src/contexts/AuthContext.tsx
+++ b/front/src/contexts/AuthContext.tsx
@@ -1,9 +1,16 @@
 "use client";
 
-import { createContext, useContext, useState, ReactNode, useEffect } from 'react';
-import { User, AuthContextType } from '@/lib/types';
-import { checkSession } from '@/lib/axios';
-import Cookies from 'js-cookie';
+import {
+  createContext,
+  useContext,
+  useState,
+  ReactNode,
+  useEffect,
+} from "react";
+import { User, AuthContextType } from "@/lib/types";
+import { checkSession } from "@/lib/axios";
+import Cookies from "js-cookie";
+import { useRef } from "react";
 
 // 認証コンテキストの作成
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -12,6 +19,7 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
+  const isLoggingOutRef = useRef(false);
 
   console.log("認証コンテキストプロバイダーコンポーネントチェック");
 
@@ -21,7 +29,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const validateSession = async () => {
       try {
         // authCookieが存在する場合のみセッションを確認
-        const authCookie = Cookies.get('auth');
+        const authCookie = Cookies.get("auth");
         console.log(authCookie);
         if (authCookie) {
           console.log("セッション確認開始");
@@ -29,7 +37,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           setUser(userData);
         }
       } catch (error) {
-        console.error('Session validation failed:', error);
+        console.error("Session validation failed:", error);
         console.log("セッション確認失敗");
       } finally {
         setLoading(false);
@@ -46,11 +54,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }
 
   return (
-    <AuthContext.Provider value={{
-      user,
-      setUser,
-      isAuthenticated: !!user,
-    }}>
+    <AuthContext.Provider
+      value={{
+        user,
+        setUser,
+        isAuthenticated: !!user,
+        isLoggingOutRef,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   );
@@ -60,7 +71,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 export function useAuth() {
   const context = useContext(AuthContext);
   if (context === undefined) {
-    throw new Error('useAuth must be used within an AuthProvider');
+    throw new Error("useAuth must be used within an AuthProvider");
   }
   return context;
 }

--- a/front/src/lib/types.ts
+++ b/front/src/lib/types.ts
@@ -30,6 +30,7 @@ export interface User {
     user: User | null;
     setUser: (user: User | null | ((prev: User | null) => User | null)) => void;
     isAuthenticated: boolean;
+    isLoggingOutRef: React.MutableRefObject<boolean>;
   }
 
   // 投稿の型定義


### PR DESCRIPTION
## 概要
タイピング結果画面のランキングの表示が正しく表示されるように修正しました。

## 実装内容
バックエンド
- [ ] 仮のランキングを算出するロジックを修正

フロントエンド
- [ ] ランキングを保存する前に、仮のランキングを算出するように修正

## その他
・ログアウト後にtopページに戻るように修正
・マイページでログアウトした場合、エラーページに飛んでしまう不具合を修正

## issue
#142 