### PR TITLE
【フロント・バック】いいね機能の実装

### DIFF
--- a/back/app/controllers/api/v1/likes_controller.rb
+++ b/back/app/controllers/api/v1/likes_controller.rb
@@ -1,0 +1,35 @@
+class Api::V1::LikesController < ApplicationController
+  before_action :authenticate_api_v1_user!
+
+  # 投稿にいいねしているユーザーの一覧を取得
+  def index
+    post = Post.find(params[:post_id])
+    users = post.likes.includes(:user).map(&:user)
+    render json: users, status: :ok
+  end
+
+  # 投稿にいいねする
+  def create
+    post = Post.find(params[:post_id])
+    like = current_api_v1_user.likes.build(post: post)
+
+    if like.save
+      render json: { success: true, likes_count: post.reload.likes_count }
+    else
+      render json: { success: false, message: like.errors.full_messages.join(", "), likes_count: post.likes_count }, status: :unprocessable_entity
+    end
+  end
+
+  # 投稿からいいねを外す
+  def destroy
+    post = Post.find(params[:post_id])
+    like = current_api_v1_user.likes.find_by(post: post)
+
+    if like
+      like.destroy
+      render json: { success: true, likes_count: post.reload.likes_count }
+    else
+      render json: { success: false, message: "いいねが見つかりません" }, status: :not_found
+    end
+  end
+end

--- a/back/app/controllers/api/v1/mypage_controller.rb
+++ b/back/app/controllers/api/v1/mypage_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::MypageController < ApplicationController
   before_action :authenticate_api_v1_user!
 
+  # 自分のタイピング結果を取得
   def typing_results
     @typing_games = TypingGame
       .select("DISTINCT ON (post_id) *")
@@ -9,10 +10,20 @@ class Api::V1::MypageController < ApplicationController
 
     render json: @typing_games
   end
+
+  # 自分の投稿を取得
   def posts
     @posts = current_api_v1_user.posts.order(created_at: :desc)
     render json: @posts
   end
+
+  # いいねした投稿を取得
+  # def liked_posts
+  #   posts = current_api_v1_user.likes.includes(:post).map(&:post)
+  #   render json: posts, status: :ok
+  # end
+
+  # 自分のプロフィール画像を更新
   def update_profile_image
     if current_api_v1_user.update(profile_image_params)
       render json: { profile_image_url: current_api_v1_user.profile_image.url }, status: :ok

--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -7,12 +7,14 @@ class Api::V1::UsersController < ApplicationController
     render json: { error: "ユーザーが見つかりません" }, status: :not_found
   end
 
+  # 全ユーザー情報を取得
   def index
     users = User.select(:id, :name, :profile_image, :bio, :total_play_count, :posts_count, :created_at).order(created_at: :desc)
 
     render json: users, status: :ok
   end
 
+  # ユーザーの投稿を取得
   def posts
     puts "Requested User ID: #{params[:id]}" # ログ確認
     user = User.find_by(id: params[:id])
@@ -25,6 +27,7 @@ class Api::V1::UsersController < ApplicationController
     end
   end
 
+  # ユーザーのタイピング結果を取得
   def user_typing_results
     user = User.find_by(id: params[:id])
 
@@ -39,4 +42,11 @@ class Api::V1::UsersController < ApplicationController
       render json: { error: "User not found" }, status: :not_found
     end
   end
+
+  # ユーザーのいいねした投稿を取得
+  # def liked_posts
+  #   user = User.find(params[:id])
+  #   posts = user.likes.includes(:post).map(&:post)
+  #   render json: posts, status: :ok
+  # end
 end

--- a/back/app/models/like.rb
+++ b/back/app/models/like.rb
@@ -1,0 +1,6 @@
+class Like < ApplicationRecord
+  belongs_to :user
+  belongs_to :post, counter_cache: true
+
+  validates :user_id, uniqueness: { scope: :post_id }
+end

--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -1,7 +1,9 @@
 class Post < ApplicationRecord
   belongs_to :user
-  # 削除時に関連するタイピングゲームも同時に削除
-  has_many :typing_games, dependent: :destroy
+  
+  has_many :typing_games, dependent: :destroy # 削除時に関連するタイピングゲームも同時に削除
+  has_many :likes, dependent: :destroy # 削除時に関連するいいねも同時に削除
+  has_many :liked_users, through: :likes, source: :user # いいねしたユーザーを取得
 
   validates :title, presence: true, length: { maximum: 40 }
   validates :description, length: { maximum: 500 }, allow_blank: true
@@ -11,12 +13,9 @@ class Post < ApplicationRecord
   mount_uploader :thumbnail_image, PostThumbnailUploader
 
   # コールバック
-  # 投稿削除時にサムネイルファイルも削除
-  before_destroy :remove_thumbnail_file
-  # サムネイル変更前に古いファイルのパスを記憶
-  before_update  :remember_old_thumbnail
-  # サムネイル変更後に古いファイルを削除
-  after_update   :remove_old_thumbnail
+  before_destroy :remove_thumbnail_file # 投稿削除時にサムネイルファイルも削除
+  before_update  :remember_old_thumbnail # サムネイル変更前に古いファイルのパスを記憶
+  after_update   :remove_old_thumbnail # サムネイル変更後に古いファイルを削除
 
   # 投稿削除時にサムネイル画像をストレージから削除
   def remove_thumbnail_file

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -8,7 +8,9 @@ class User < ActiveRecord::Base
   include DeviseTokenAuth::Concerns::User
 
   has_many :posts, dependent: :destroy # ユーザーが削除されたら、関連する投稿も削除
-  has_many :typing_games, dependent: :destroy # # ユーザーが削除されたら、タイピング成績も削除
+  has_many :typing_games, dependent: :destroy # ユーザーが削除されたら、タイピング成績も削除
+  has_many :likes, dependent: :destroy # ユーザーが削除されたら、いいねも削除
+  has_many :liked_posts, through: :likes, source: :post # いいねした投稿
 
   # プロフィール画像のアップローダー
   mount_uploader :profile_image, ProfileImageUploader

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
       # マイページのエンドポイント
       get "mypage/posts", to: "mypage#posts"
       get "mypage/typing_results", to: "mypage#typing_results"
+      # get "mypage/liked_posts", to: "mypage#liked_posts"
       put "mypage/profile_image", to: "mypage#update_profile_image"
 
       # ユーザー情報取得のエンドポイント
@@ -23,6 +24,7 @@ Rails.application.routes.draw do
         member do
           get "posts", to: "users#posts"
           get "user_typing_results", to: "users#user_typing_results"
+          # get "liked_posts", to: "users#liked_posts"
         end
       end
 
@@ -30,7 +32,11 @@ Rails.application.routes.draw do
       resources :posts, only: [ :index, :show, :create, :update, :destroy ] do
         member do
           post "upload_thumbnail", to: "posts#upload_thumbnail"
+          get "likes", to: "likes#index"
         end
+
+        # likeのエンドポイント
+        resource :like, only: [:create, :destroy]
       end
 
       # タイピングゲームのエンドポイント

--- a/back/db/migrate/20250730122059_create_likes.rb
+++ b/back/db/migrate/20250730122059_create_likes.rb
@@ -1,0 +1,13 @@
+class CreateLikes < ActiveRecord::Migration[7.2]
+  def change
+    create_table :likes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    # 同じユーザーが同じ投稿に複数回「いいね」できないようにする制約
+    add_index :likes, [:user_id, :post_id], unique: true
+  end
+end

--- a/back/db/migrate/20250730135922_add_likes_count_to_posts.rb
+++ b/back/db/migrate/20250730135922_add_likes_count_to_posts.rb
@@ -1,0 +1,5 @@
+class AddLikesCountToPosts < ActiveRecord::Migration[7.2]
+  def change
+    add_column :posts, :likes_count, :integer, default: 0, null: false
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_24_014658) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_30_135922) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "likes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_likes_on_post_id"
+    t.index ["user_id", "post_id"], name: "index_likes_on_user_id_and_post_id", unique: true
+    t.index ["user_id"], name: "index_likes_on_user_id"
+  end
 
   create_table "posts", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -24,6 +34,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_24_014658) do
     t.integer "typing_play_count", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "likes_count", default: 0, null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
@@ -61,6 +72,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_24_014658) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "likes", "posts"
+  add_foreign_key "likes", "users"
   add_foreign_key "posts", "users"
   add_foreign_key "typing_games", "posts"
   add_foreign_key "typing_games", "users"

--- a/back/test/controllers/api/v1/likes_controller_test.rb
+++ b/back/test/controllers/api/v1/likes_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::V1::LikesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/front/src/lib/axios.ts
+++ b/front/src/lib/axios.ts
@@ -11,6 +11,7 @@ import {
   TypingResult,
   GetPseudoRankParams,
   PseudoRankResult,
+  LikeResponse,
 } from "./types";
 
 const api = axios.create({
@@ -248,4 +249,16 @@ export async function uploadThumbnailImage(
   });
 
   return response.data;
+}
+
+// いいね追加
+export async function likePost(postId: string): Promise<LikeResponse> {
+  const response = await api.post(`/posts/${postId}/like`)
+  return response.data
+}
+
+// いいね削除
+export async function unlikePost(postId: string): Promise<LikeResponse> {
+  const response = await api.delete(`/posts/${postId}/like`)
+  return response.data
 }

--- a/front/src/lib/types.ts
+++ b/front/src/lib/types.ts
@@ -9,31 +9,31 @@ export interface User {
   posts_count: number;
 }
 
-  export interface LoginResponse {
-    data: User;
-  }
+export interface LoginResponse {
+  data: User;
+}
 
-  export interface RegisterParams {
-    name: string;
-    email: string;
-    password: string;
-    password_confirmation: string;
-  }
+export interface RegisterParams {
+  name: string;
+  email: string;
+  password: string;
+  password_confirmation: string;
+}
 
-  export interface UpdateProfileParams {
-    name: string;
-    bio?: string;
-  }
+export interface UpdateProfileParams {
+  name: string;
+  bio?: string;
+}
 
-  // 認証コンテキストの型定義
-  export interface AuthContextType {
-    user: User | null;
-    setUser: (user: User | null | ((prev: User | null) => User | null)) => void;
-    isAuthenticated: boolean;
-    isLoggingOutRef: React.MutableRefObject<boolean>;
-  }
+// 認証コンテキストの型定義
+export interface AuthContextType {
+  user: User | null;
+  setUser: (user: User | null | ((prev: User | null) => User | null)) => void;
+  isAuthenticated: boolean;
+  isLoggingOutRef: React.MutableRefObject<boolean>;
+}
 
-  // 投稿の型定義
+// 投稿の型定義
 export interface Post {
   id: string;
   user_id: string;
@@ -45,7 +45,9 @@ export interface Post {
   created_at: string;
   updated_at: string;
   // tags: string[]; // タグ機能実装時に追加
-  user?: User
+  user?: User;
+  likes_count?: number;
+  is_liked?: boolean;
 }
 
 // 投稿作成時のパラメータ
@@ -59,14 +61,14 @@ export interface CreatePostParams {
 
 // タイピング結果の型定義
 export interface TypingResult {
-  id: string
-  user_id: string
-  post_id: string
-  play_time: number
-  accuracy: number
-  mistake_count: number
-  created_at: string
-  post?: Post
+  id: string;
+  user_id: string;
+  post_id: string;
+  play_time: number;
+  accuracy: number;
+  mistake_count: number;
+  created_at: string;
+  post?: Post;
   rank?: number;
   user_name?: string;
   total_players?: number;
@@ -74,21 +76,27 @@ export interface TypingResult {
 
 // タイピング結果を保存するためのパラメータ
 export interface SaveTypingResultParams {
-  post_id: string
-  play_time: number
-  accuracy: number
-  mistake_count: number
+  post_id: string;
+  play_time: number;
+  accuracy: number;
+  mistake_count: number;
 }
 
 // 擬似ランキングを取得するためのパラメータ
 export interface GetPseudoRankParams {
-  post_id: string
-  play_time: number
-  accuracy: number
+  post_id: string;
+  play_time: number;
+  accuracy: number;
 }
 
 // 擬似ランキングの型定義
 export interface PseudoRankResult {
   rank: number;
   total_players: number;
+}
+
+export interface LikeResponse {
+  success: boolean;
+  likes_count: number;
+  message?: string;
 }


### PR DESCRIPTION
## 概要
いいね機能を実装しました。

## 実装内容
バックエンド
- [x] Likesテーブルを作成
- [x] モデルの修正
- [x] likesコントローラーを作成
- [x] ルーティングの設定
- [x] いいね数をカウントするためのカラムをPostsテーブルに追加
- [x] postsコントローラーの修正

フロントエンド
- [x] PostCardコンポーネントにいいねボタンを追加
- [x] いいね数をカウントするための数字を表示

## その他

## issue
#46 
