### PR TITLE
【フロント・バック】いいね機能（ツールチップ）の追加

### DIFF
--- a/back/app/controllers/api/v1/likes_controller.rb
+++ b/back/app/controllers/api/v1/likes_controller.rb
@@ -1,35 +1,45 @@
 class Api::V1::LikesController < ApplicationController
   before_action :authenticate_api_v1_user!
+  before_action :set_post
 
   # 投稿にいいねしているユーザーの一覧を取得
-  def index
-    post = Post.find(params[:post_id])
-    users = post.likes.includes(:user).map(&:user)
+  def users
+    users = @post.likes.includes(:user).map(&:user).map do |user|
+      {
+        id: user.id,
+        name: user.name,
+        profile_image: user.profile_image,
+      }
+    end
     render json: users, status: :ok
   end
 
   # 投稿にいいねする
   def create
-    post = Post.find(params[:post_id])
-    like = current_api_v1_user.likes.build(post: post)
+    like = current_api_v1_user.likes.build(post: @post)
 
     if like.save
-      render json: { success: true, likes_count: post.reload.likes_count }
+      render json: { success: true, likes_count: @post.reload.likes_count }
     else
-      render json: { success: false, message: like.errors.full_messages.join(", "), likes_count: post.likes_count }, status: :unprocessable_entity
+      render json: { success: false, message: like.errors.full_messages.join(", "), likes_count: @post.likes_count }, status: :unprocessable_entity
     end
   end
 
   # 投稿からいいねを外す
   def destroy
-    post = Post.find(params[:post_id])
-    like = current_api_v1_user.likes.find_by(post: post)
+    like = current_api_v1_user.likes.find_by(post: @post)
 
     if like
       like.destroy
-      render json: { success: true, likes_count: post.reload.likes_count }
+      render json: { success: true, likes_count: @post.reload.likes_count }
     else
       render json: { success: false, message: "いいねが見つかりません" }, status: :not_found
     end
+  end
+
+  private
+
+  def set_post
+    @post = Post.find(params[:post_id])
   end
 end

--- a/back/app/controllers/api/v1/mypage_controller.rb
+++ b/back/app/controllers/api/v1/mypage_controller.rb
@@ -13,8 +13,8 @@ class Api::V1::MypageController < ApplicationController
 
   # 自分の投稿を取得
   def posts
-    @posts = current_api_v1_user.posts.order(created_at: :desc)
-    render json: @posts
+    posts = current_api_v1_user.posts.includes(:likes)
+    render json: posts.map { |post| post_response(post) }
   end
 
   # いいねした投稿を取得
@@ -23,7 +23,7 @@ class Api::V1::MypageController < ApplicationController
   #   render json: posts, status: :ok
   # end
 
-  # 自分のプロフィール画像を更新
+  # 自分のプロフィール画像を更新
   def update_profile_image
     if current_api_v1_user.update(profile_image_params)
       render json: { profile_image_url: current_api_v1_user.profile_image.url }, status: :ok

--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -62,22 +62,4 @@ class Api::V1::PostsController < ApplicationController
   def post_params
     params.require(:post).permit(:title, :description, :display_text, :typing_text, :thumbnail_image, :remote_thumbnail_image_url)
   end
-
-  # 投稿レスポンス用メソッド
-  def post_response(post)
-    {
-      id: post.id,
-      user_id: post.user_id,
-      title: post.title,
-      description: post.description,
-      display_text: post.display_text,
-      typing_text: post.typing_text,
-      thumbnail_image: post.thumbnail_image,
-      typing_play_count: post.typing_play_count,
-      likes_count: post.likes_count,
-      is_liked: current_api_v1_user ? post.likes.exists?(user_id: current_api_v1_user.id) : false,
-      created_at: post.created_at,
-      updated_at: post.updated_at
-    }
-  end
 end

--- a/back/app/controllers/api/v1/users_controller.rb
+++ b/back/app/controllers/api/v1/users_controller.rb
@@ -16,12 +16,11 @@ class Api::V1::UsersController < ApplicationController
 
   # ユーザーの投稿を取得
   def posts
-    puts "Requested User ID: #{params[:id]}" # ログ確認
     user = User.find_by(id: params[:id])
 
     if user
-      posts = user.posts.order(created_at: :desc) # 最新の投稿を先に表示
-      render json: posts, status: :ok
+      posts = user.posts.includes(:likes).order(created_at: :desc)
+      render json: posts.map { |post| post_response(post) }
     else
       render json: { error: "User not found" }, status: :not_found
     end
@@ -43,10 +42,15 @@ class Api::V1::UsersController < ApplicationController
     end
   end
 
-  # ユーザーのいいねした投稿を取得
+  # # ユーザーのいいねした投稿を取得
   # def liked_posts
-  #   user = User.find(params[:id])
-  #   posts = user.likes.includes(:post).map(&:post)
-  #   render json: posts, status: :ok
+  #   user = User.find_by(id: params[:id])
+
+  #   if user
+  #     posts = user.likes.includes(post: :likes).map(&:post)
+  #     render json: posts.map { |post| post_response(post) }
+  #   else
+  #     render json: { error: "User not found" }, status: :not_found
+  #   end
   # end
 end

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -1,3 +1,23 @@
 class ApplicationController < ActionController::API
   include DeviseTokenAuth::Concerns::SetUserByToken
+
+  private
+
+  # 投稿レスポンス用メソッド
+  def post_response(post)
+    {
+      id: post.id,
+      user_id: post.user_id,
+      title: post.title,
+      description: post.description,
+      display_text: post.display_text,
+      typing_text: post.typing_text,
+      thumbnail_image: post.thumbnail_image,
+      typing_play_count: post.typing_play_count,
+      likes_count: post.likes_count,
+      is_liked: current_api_v1_user ? post.likes.exists?(user_id: current_api_v1_user.id) : false,
+      created_at: post.created_at,
+      updated_at: post.updated_at
+    }
+  end
 end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -32,11 +32,12 @@ Rails.application.routes.draw do
       resources :posts, only: [ :index, :show, :create, :update, :destroy ] do
         member do
           post "upload_thumbnail", to: "posts#upload_thumbnail"
-          get "likes", to: "likes#index"
         end
 
         # likeのエンドポイント
-        resource :like, only: [:create, :destroy]
+        resource :like, only: [:create, :destroy] do
+          get :users, on: :collection
+        end
       end
 
       # タイピングゲームのエンドポイント

--- a/front/src/lib/axios.ts
+++ b/front/src/lib/axios.ts
@@ -253,12 +253,18 @@ export async function uploadThumbnailImage(
 
 // いいね追加
 export async function likePost(postId: string): Promise<LikeResponse> {
-  const response = await api.post(`/posts/${postId}/like`)
-  return response.data
+  const response = await api.post(`/posts/${postId}/like`);
+  return response.data;
 }
 
 // いいね削除
 export async function unlikePost(postId: string): Promise<LikeResponse> {
-  const response = await api.delete(`/posts/${postId}/like`)
-  return response.data
+  const response = await api.delete(`/posts/${postId}/like`);
+  return response.data;
+}
+
+// いいねしたユーザー一覧を取得
+export async function getLikedUsers(postId: string): Promise<User[]> {
+  const response = await api.get(`/posts/${postId}/like/users`);
+  return response.data;
 }


### PR DESCRIPTION
## 概要
いいねボタンでホバーしたときにいいねしたユーザーを表示するようにしました。

## 実装内容
バックエンド
- [x] 投稿にいいねしているユーザーの一覧を取得するメソッドを追加
- [x] ルーティングの修正

フロントエンド
- [x] ツールチップを追加
- [x] バックエンドからユーザーの一覧を取得する処理を追加

## その他
マイページ、ユーザーページを開いた時にいいねした投稿のいいねボタンが非活性で表示する不具合を修正しました。

## issue
#145 
