### PR TITLE
【フロント】fix:いいね一覧で投稿を削除した時の挙動を修正

### DIFF
--- a/front/src/components/Likes-list.tsx
+++ b/front/src/components/Likes-list.tsx
@@ -86,7 +86,13 @@ export default function LikesList({
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-6">
         {currentPosts.map((post) => (
           <Link href={`/posts/${post.id}`} key={post.id} className="block">
-            <PostCard post={post} setPosts={setPosts} isMyPage={false} />
+            <PostCard
+              post={post}
+              setPosts={setPosts}
+              isMyPage={isMyPage}
+              isLikesList={true}
+              userId={userId}
+            />
           </Link>
         ))}
       </div>

--- a/front/src/components/PostCard.tsx
+++ b/front/src/components/PostCard.tsx
@@ -25,9 +25,11 @@ interface PostCardProps {
   post: Post;
   setPosts: React.Dispatch<React.SetStateAction<Post[]>>;
   isMyPage?: boolean;
+  isLikesList?: boolean;
+  userId?: string;
 }
 
-const PostCard: React.FC<PostCardProps> = ({ post, setPosts, isMyPage }) => {
+const PostCard: React.FC<PostCardProps> = ({ post, setPosts, isMyPage, isLikesList, userId }) => {
   const { user } = useAuth(); // 現在のユーザー情報を取得
   const { handleDelete } = useDeletePost();
   const [postUser, setPostUser] = useState<User | null>(null);
@@ -149,7 +151,11 @@ const PostCard: React.FC<PostCardProps> = ({ post, setPosts, isMyPage }) => {
   const handleDeleteClick = (event: React.MouseEvent) => {
     event.preventDefault(); // 親の Link の遷移を防ぐ
     event.stopPropagation(); // イベントの伝播を防ぐ
-    handleDelete(post.id, post.title, setPosts, isMyPage);
+    handleDelete(post.id, post.title, setPosts, {
+      isMyPage,
+      isLikesList,
+      userId,
+    });
   };
 
   // いいね/いいね解除の処理


### PR DESCRIPTION
## 概要
いいね一覧で投稿を削除したら、全ての投稿を表示してしまう挙動を修正しました。

## 実装内容
- [x] いいね一覧からの処理かどうかのフラグを追加
- [x] いいね一覧から削除処理を走らせた時に、いいね一覧を再取得する処理を追加

## その他

## issue
#151 