### PR TITLE
【フロント】投稿詳細ページにいいねボタンを追加

### DIFF
--- a/front/src/app/posts/[id]/page.tsx
+++ b/front/src/app/posts/[id]/page.tsx
@@ -33,6 +33,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from "@/components/ui/dropdown-menu";
+import { LikeButtonWithTooltip } from "@/components/LikeButtonWithTooltip";
 
 // 共通のヘルパー関数
 const getProfileImageUrl = (profileImage?: string | { url: string }) => {
@@ -66,6 +67,10 @@ export default function PostDetailPage() {
   const [showMoreRanking, setShowMoreRanking] = useState(false);
   const [rankingUsers, setRankingUsers] = useState<{ [key: string]: User }>({}); // ランキングユーザー情報をキャッシュ
 
+  // いいね関連の状態
+  const [isLiked, setIsLiked] = useState<boolean>(false);
+  const [likesCount, setLikesCount] = useState<number>(0);
+
   // コメント関連の状態
   const [comments, setComments] = useState<Comment[]>([]);
   const [commentsLoading, setCommentsLoading] = useState(true);
@@ -87,6 +92,9 @@ export default function PostDetailPage() {
       try {
         const data = await getPost(post_id);
         setPost(data);
+        // いいね状態の初期化
+        setIsLiked(data.is_liked || false);
+        setLikesCount(data.likes_count || 0);
       } catch (error) {
         console.error("Error fetching post:", error);
         toast.error("投稿の取得に失敗しました");
@@ -210,6 +218,12 @@ export default function PostDetailPage() {
     } catch (error) {
       console.error("Error refreshing ranking:", error);
     }
+  };
+
+  // いいね状態変更のハンドラ
+  const handleLikeChange = (newIsLiked: boolean, newLikesCount: number) => {
+    setIsLiked(newIsLiked);
+    setLikesCount(newLikesCount);
   };
 
   // コメント送信
@@ -355,7 +369,7 @@ export default function PostDetailPage() {
     if (rank === 1) {
       return (
         <Image
-          src={ranking_1_image}
+          src={ranking_1_image || "/placeholder.svg"}
           alt="1位"
           width={40}
           height={40}
@@ -366,7 +380,7 @@ export default function PostDetailPage() {
     if (rank === 2) {
       return (
         <Image
-          src={ranking_2_image}
+          src={ranking_2_image || "/placeholder.svg"}
           alt="2位"
           width={40}
           height={40}
@@ -377,7 +391,7 @@ export default function PostDetailPage() {
     if (rank === 3) {
       return (
         <Image
-          src={ranking_3_image}
+          src={ranking_3_image || "/placeholder.svg"}
           alt="3位"
           width={40}
           height={40}
@@ -420,7 +434,7 @@ export default function PostDetailPage() {
               <Button
                 variant="outline"
                 size="sm"
-                className="w-full max-w-xs text-md bg-transparent"
+                className="w-full max-w-xs text-md"
               >
                 編集する
               </Button>
@@ -472,7 +486,7 @@ export default function PostDetailPage() {
             <Avatar className="h-12 w-12 border-white border-2 shadow-md transition-all duration-300">
               {postUserProfileImageUrl ? (
                 <AvatarImage
-                  src={String(postUserProfileImageUrl)}
+                  src={String(postUserProfileImageUrl) || "/placeholder.svg"}
                   alt={postUser?.name || "投稿者画像"}
                 />
               ) : (
@@ -487,8 +501,18 @@ export default function PostDetailPage() {
           </div>
           <div className="flex items-center gap-4">
             <div className="text-sm text-gray-500">
-              公開日：{new Date(post.created_at).toLocaleDateString()}
+              {new Date(post.created_at).getTime() !==
+              new Date(post.updated_at).getTime()
+                ? `更新日：${new Date(post.updated_at).toLocaleDateString()}`
+                : `公開日：${new Date(post.created_at).toLocaleDateString()}`}
             </div>
+            {/* Like Button */}
+            <LikeButtonWithTooltip
+              postId={post_id}
+              isLiked={isLiked}
+              likesCount={likesCount}
+              onLikeChange={handleLikeChange}
+            />
           </div>
         </div>
 
@@ -585,7 +609,10 @@ export default function PostDetailPage() {
                             <Avatar className="h-10 w-10">
                               {commentUserProfileImageUrl ? (
                                 <AvatarImage
-                                  src={String(commentUserProfileImageUrl)}
+                                  src={
+                                    String(commentUserProfileImageUrl) ||
+                                    "/placeholder.svg"
+                                  }
                                   alt={
                                     comment.user?.name || "コメントユーザー画像"
                                   }
@@ -783,7 +810,10 @@ export default function PostDetailPage() {
                           <Avatar className="h-10 w-10">
                             {rankingUserProfileImageUrl ? (
                               <AvatarImage
-                                src={String(rankingUserProfileImageUrl)}
+                                src={
+                                  String(rankingUserProfileImageUrl) ||
+                                  "/placeholder.svg"
+                                }
                                 alt={
                                   result.user_name || "ランキングユーザー画像"
                                 }

--- a/front/src/components/LikeButtonWithTooltip.tsx
+++ b/front/src/components/LikeButtonWithTooltip.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import type React from "react";
+import { useState, useEffect, useRef } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { AiFillHeart, AiOutlineHeart } from "react-icons/ai";
+import { Button } from "@/components/ui/button";
+import { likePost, unlikePost, getLikedUsers } from "@/lib/axios";
+import type { User } from "@/lib/types";
+import toast from "react-hot-toast";
+import { LikedUsersModal } from "./LikedUsersModal";
+
+interface LikeButtonWithTooltipProps {
+  postId: string;
+  isLiked: boolean;
+  likesCount: number;
+  onLikeChange: (isLiked: boolean, likesCount: number) => void;
+  disabled?: boolean;
+  className?: string;
+  size?: "default" | "sm" | "lg" | "icon" | "like" | "linkSmall";
+  variant?:
+    | "default"
+    | "destructive"
+    | "outline"
+    | "secondary"
+    | "ghost"
+    | "link"
+    | "like"
+    | "linkSmall";
+}
+
+export function LikeButtonWithTooltip({
+  postId,
+  isLiked,
+  likesCount,
+  onLikeChange,
+  disabled = false,
+  className = "",
+  size = "like",
+  variant = "like",
+}: LikeButtonWithTooltipProps) {
+  const { user } = useAuth();
+  const [isLikeLoading, setIsLikeLoading] = useState<boolean>(false);
+
+  // ツールチップ関連の状態
+  const [showTooltip, setShowTooltip] = useState<boolean>(false);
+  const [likedUsers, setLikedUsers] = useState<User[]>([]);
+  const [isLoadingLikedUsers, setIsLoadingLikedUsers] =
+    useState<boolean>(false);
+  const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const tooltipTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  // モーダル関連の状態
+  const [showLikedUsersModal, setShowLikedUsersModal] =
+    useState<boolean>(false);
+
+  // いいねしたユーザーを取得する関数
+  const fetchLikedUsers = async () => {
+    if (isLoadingLikedUsers) return;
+
+    try {
+      setIsLoadingLikedUsers(true);
+      const users = await getLikedUsers(postId);
+      setLikedUsers(users);
+    } catch (error) {
+      console.error("Failed to fetch liked users:", error);
+      setLikedUsers([]);
+    } finally {
+      setIsLoadingLikedUsers(false);
+    }
+  };
+
+  // ツールチップ表示のハンドラ
+  const handleMouseEnter = () => {
+    // 既存のタイムアウトをクリア
+    if (hoverTimeoutRef.current) {
+      clearTimeout(hoverTimeoutRef.current);
+    }
+    if (tooltipTimeoutRef.current) {
+      clearTimeout(tooltipTimeoutRef.current);
+    }
+
+    // 400ms後にツールチップを表示
+    hoverTimeoutRef.current = setTimeout(() => {
+      setShowTooltip(true);
+      fetchLikedUsers();
+    }, 400);
+  };
+
+  // ツールチップ非表示のハンドラ
+  const handleMouseLeave = () => {
+    // ホバータイムアウトをクリア
+    if (hoverTimeoutRef.current) {
+      clearTimeout(hoverTimeoutRef.current);
+    }
+
+    // 少し遅延してツールチップを非表示
+    tooltipTimeoutRef.current = setTimeout(() => {
+      setShowTooltip(false);
+    }, 200);
+  };
+
+  // ツールチップ上でのマウスイベント
+  const handleTooltipMouseEnter = () => {
+    if (tooltipTimeoutRef.current) {
+      clearTimeout(tooltipTimeoutRef.current);
+    }
+  };
+
+  const handleTooltipMouseLeave = () => {
+    tooltipTimeoutRef.current = setTimeout(() => {
+      setShowTooltip(false);
+    }, 200);
+  };
+
+  // ツールチップ内でのクリックイベント処理
+  const handleTooltipClick = (event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  // コンポーネントのクリーンアップ
+  useEffect(() => {
+    return () => {
+      if (hoverTimeoutRef.current) {
+        clearTimeout(hoverTimeoutRef.current);
+      }
+      if (tooltipTimeoutRef.current) {
+        clearTimeout(tooltipTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  // いいね/いいね解除の処理
+  const handleLikeClick = async (event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (!user) {
+      toast.error("ログインが必要です");
+      return;
+    }
+
+    if (isLikeLoading) return;
+
+    try {
+      setIsLikeLoading(true);
+
+      if (isLiked) {
+        // いいね解除
+        const response = await unlikePost(postId);
+        if (response.success) {
+          onLikeChange(false, response.likes_count);
+          toast.success("いいねを解除しました");
+
+          // ツールチップが表示されている場合、リストから自分を削除
+          if (showTooltip) {
+            setLikedUsers((prev) => prev.filter((u) => u.id !== user.id));
+          }
+        }
+      } else {
+        // いいね追加
+        const response = await likePost(postId);
+        if (response.success) {
+          onLikeChange(true, response.likes_count);
+          toast.success("いいねをしました");
+
+          // ツールチップが表示されている場合、リストに自分を追加
+          if (showTooltip && user) {
+            setLikedUsers((prev) => [user, ...prev]);
+          }
+        }
+      }
+    } catch (error) {
+      console.error("Like operation failed:", error);
+      toast.error("いいね操作に失敗しました");
+    } finally {
+      setIsLikeLoading(false);
+    }
+  };
+
+  // いいねしたユーザー名を文字列として結合
+  const getLikedUsersText = () => {
+    if (likedUsers.length === 0) {
+      return "";
+    }
+    return likedUsers.map((user) => user.name).join("、");
+  };
+
+  // モーダルを開く関数
+  const handleShowMoreClick = (event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setShowTooltip(false); // ツールチップを閉じる
+    setShowLikedUsersModal(true); // モーダルを開く
+  };
+
+  return (
+    <>
+      <div
+        className="relative"
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        <Button
+          variant={variant}
+          size={size}
+          onClick={handleLikeClick}
+          disabled={isLikeLoading || disabled || !user}
+          data-liked={isLiked}
+          className={className}
+        >
+          {isLiked ? (
+            <AiFillHeart className="w-5 h-5" />
+          ) : (
+            <AiOutlineHeart className="w-5 h-5" />
+          )}
+          <span className="font-medium">{likesCount}</span>
+        </Button>
+
+        {/* ツールチップ */}
+        {showTooltip && (
+          <div
+            className="absolute bottom-full right-0 mb-2 w-64 bg-white border border-red-300 rounded-lg shadow-lg p-3 z-50 animate-in fade-in-0 zoom-in-95 duration-200"
+            onMouseEnter={handleTooltipMouseEnter}
+            onMouseLeave={handleTooltipMouseLeave}
+            onClick={handleTooltipClick}
+          >
+            <div className="text-sm font-medium text-gray-800 mb-2">
+              いいねしたユーザー
+            </div>
+            <div className="text-sm text-gray-600 max-h-20 overflow-hidden">
+              {isLoadingLikedUsers ? (
+                <div className="text-gray-400">読み込み中...</div>
+              ) : likedUsers.length > 0 ? (
+                <div className="break-words">
+                  <span className="inline-block max-w-full truncate">
+                    {getLikedUsersText()}
+                    {getLikedUsersText().length > 100 && "..."}
+                  </span>
+                </div>
+              ) : (
+                <div className="text-gray-400">まだいいねがありません</div>
+              )}
+            </div>
+            {/* もっと見るボタン */}
+            {likedUsers.length > 0 && (
+              <div className="pt-2 border-t border-gray-200 mt-2">
+                <Button
+                  variant="linkSmall"
+                  size="linkSmall"
+                  onClick={handleShowMoreClick}
+                >
+                  もっと見る
+                </Button>
+              </div>
+            )}
+            {/* 矢印 */}
+            <div className="absolute top-full right-4 w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-red-300"></div>
+          </div>
+        )}
+      </div>
+
+      {/* いいねユーザー一覧モーダル */}
+      <LikedUsersModal
+        isOpen={showLikedUsersModal}
+        onClose={() => setShowLikedUsersModal(false)}
+        postId={postId}
+        initialUsers={likedUsers}
+      />
+    </>
+  );
+}

--- a/front/src/components/PostCard.tsx
+++ b/front/src/components/PostCard.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import type React from "react";
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { FiMoreVertical, FiEdit, FiTrash } from "react-icons/fi";
-import { AiFillHeart, AiOutlineHeart } from "react-icons/ai";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -17,9 +16,8 @@ import Image from "next/image";
 import Link from "next/link";
 import post_image_def from "/public/post_image_def.png";
 import { useDeletePost } from "@/hooks/useDeletePost";
-import { getUser, likePost, unlikePost, getLikedUsers } from "@/lib/axios";
-import toast from "react-hot-toast";
-import { LikedUsersModal } from "./LikedUsersModal";
+import { getUser } from "@/lib/axios";
+import { LikeButtonWithTooltip } from "./LikeButtonWithTooltip";
 
 interface PostCardProps {
   post: Post;
@@ -41,19 +39,6 @@ const PostCard: React.FC<PostCardProps> = ({
   const [postUser, setPostUser] = useState<User | null>(null);
   const [isLiked, setIsLiked] = useState<boolean>(post.is_liked || false);
   const [likesCount, setLikesCount] = useState<number>(post.likes_count || 0);
-  const [isLikeLoading, setIsLikeLoading] = useState<boolean>(false);
-
-  // ツールチップ関連の状態
-  const [showTooltip, setShowTooltip] = useState<boolean>(false);
-  const [likedUsers, setLikedUsers] = useState<User[]>([]);
-  const [isLoadingLikedUsers, setIsLoadingLikedUsers] =
-    useState<boolean>(false);
-  const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const tooltipTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-
-  // モーダル関連の状態
-  const [showLikedUsersModal, setShowLikedUsersModal] =
-    useState<boolean>(false);
 
   // 投稿者の取得
   useEffect(() => {
@@ -77,83 +62,6 @@ const PostCard: React.FC<PostCardProps> = ({
     setLikesCount(post.likes_count || 0);
   }, [post.is_liked, post.likes_count]);
 
-  // いいねしたユーザーを取得する関数
-  const fetchLikedUsers = async () => {
-    if (isLoadingLikedUsers) return;
-
-    try {
-      setIsLoadingLikedUsers(true);
-      const users = await getLikedUsers(post.id);
-      setLikedUsers(users);
-    } catch (error) {
-      console.error("Failed to fetch liked users:", error);
-      setLikedUsers([]);
-    } finally {
-      setIsLoadingLikedUsers(false);
-    }
-  };
-
-  // ツールチップ表示のハンドラ
-  const handleMouseEnter = () => {
-    // 既存のタイムアウトをクリア
-    if (hoverTimeoutRef.current) {
-      clearTimeout(hoverTimeoutRef.current);
-    }
-    if (tooltipTimeoutRef.current) {
-      clearTimeout(tooltipTimeoutRef.current);
-    }
-
-    // 400ms後にツールチップを表示
-    hoverTimeoutRef.current = setTimeout(() => {
-      setShowTooltip(true);
-      fetchLikedUsers();
-    }, 400);
-  };
-
-  // ツールチップ非表示のハンドラ
-  const handleMouseLeave = () => {
-    // ホバータイムアウトをクリア
-    if (hoverTimeoutRef.current) {
-      clearTimeout(hoverTimeoutRef.current);
-    }
-
-    // 少し遅延してツールチップを非表示
-    tooltipTimeoutRef.current = setTimeout(() => {
-      setShowTooltip(false);
-    }, 200);
-  };
-
-  // ツールチップ上でのマウスイベント
-  const handleTooltipMouseEnter = () => {
-    if (tooltipTimeoutRef.current) {
-      clearTimeout(tooltipTimeoutRef.current);
-    }
-  };
-
-  const handleTooltipMouseLeave = () => {
-    tooltipTimeoutRef.current = setTimeout(() => {
-      setShowTooltip(false);
-    }, 200);
-  };
-
-  // ツールチップ内でのクリックイベント処理
-  const handleTooltipClick = (event: React.MouseEvent) => {
-    event.preventDefault();
-    event.stopPropagation();
-  };
-
-  // コンポーネントのクリーンアップ
-  useEffect(() => {
-    return () => {
-      if (hoverTimeoutRef.current) {
-        clearTimeout(hoverTimeoutRef.current);
-      }
-      if (tooltipTimeoutRef.current) {
-        clearTimeout(tooltipTimeoutRef.current);
-      }
-    };
-  }, []);
-
   const handleDeleteClick = (event: React.MouseEvent) => {
     event.preventDefault(); // 親の Link の遷移を防ぐ
     event.stopPropagation(); // イベントの伝播を防ぐ
@@ -164,70 +72,19 @@ const PostCard: React.FC<PostCardProps> = ({
     });
   };
 
-  // いいね/いいね解除の処理
-  const handleLikeClick = async (event: React.MouseEvent) => {
-    event.preventDefault();
-    event.stopPropagation();
+  // いいね状態変更のハンドラ
+  const handleLikeChange = (newIsLiked: boolean, newLikesCount: number) => {
+    setIsLiked(newIsLiked);
+    setLikesCount(newLikesCount);
 
-    if (!user) {
-      toast.error("ログインが必要です");
-      return;
-    }
-
-    if (isLikeLoading) return;
-
-    try {
-      setIsLikeLoading(true);
-
-      if (isLiked) {
-        // いいね解除
-        const response = await unlikePost(post.id);
-        if (response.success) {
-          setIsLiked(false);
-          setLikesCount(response.likes_count);
-
-          // ツールチップが表示されている場合、リストから自分を削除
-          if (showTooltip) {
-            setLikedUsers((prev) => prev.filter((u) => u.id !== user.id));
-          }
-
-          // 投稿リストの状態も更新
-          setPosts((prevPosts) =>
-            prevPosts.map((p) =>
-              p.id === post.id
-                ? { ...p, is_liked: false, likes_count: response.likes_count }
-                : p
-            )
-          );
-        }
-      } else {
-        // いいね追加
-        const response = await likePost(post.id);
-        if (response.success) {
-          setIsLiked(true);
-          setLikesCount(response.likes_count);
-
-          // ツールチップが表示されている場合、リストに自分を追加
-          if (showTooltip && user) {
-            setLikedUsers((prev) => [user, ...prev]);
-          }
-
-          // 投稿リストの状態も更新
-          setPosts((prevPosts) =>
-            prevPosts.map((p) =>
-              p.id === post.id
-                ? { ...p, is_liked: true, likes_count: response.likes_count }
-                : p
-            )
-          );
-        }
-      }
-    } catch (error) {
-      console.error("Like operation failed:", error);
-      toast.error("いいね操作に失敗しました");
-    } finally {
-      setIsLikeLoading(false);
-    }
+    // 投稿リストの状態も更新
+    setPosts((prevPosts) =>
+      prevPosts.map((p) =>
+        p.id === post.id
+          ? { ...p, is_liked: newIsLiked, likes_count: newLikesCount }
+          : p
+      )
+    );
   };
 
   // ユーザー名の表示用関数
@@ -279,29 +136,6 @@ const PostCard: React.FC<PostCardProps> = ({
     event.preventDefault(); // 親のLinkの遷移を防ぐ
     event.stopPropagation(); // イベントの伝播を防ぐ
     window.location.href = getUserProfileLink(); // 直接URLを変更
-  };
-
-  // いいねしたユーザー名を文字列として結合
-  const getLikedUsersText = () => {
-    if (likedUsers.length === 0) {
-      return "";
-    }
-    return likedUsers.map((user) => user.name).join("、");
-  };
-
-  // モーダルを開く関数
-  const handleShowMoreClick = (event: React.MouseEvent) => {
-    event.preventDefault();
-    event.stopPropagation();
-    setShowTooltip(false); // ツールチップを閉じる
-    setShowLikedUsersModal(true); // モーダルを開く
-  };
-
-  // いいね数をクリックした時のハンドラ
-  const handleLikesCountClick = (event: React.MouseEvent) => {
-    event.preventDefault();
-    event.stopPropagation();
-    setShowLikedUsersModal(true);
   };
 
   const postUserProfileImageUrl = getPostUserProfileImageUrl();
@@ -371,7 +205,7 @@ const PostCard: React.FC<PostCardProps> = ({
           <Avatar className="h-8 w-8">
             {postUserProfileImageUrl ? (
               <AvatarImage
-                src={String(postUserProfileImageUrl)}
+                src={String(postUserProfileImageUrl) || "/placeholder.svg"}
                 alt={getUserName() || "ユーザー画像"}
               />
             ) : (
@@ -384,85 +218,16 @@ const PostCard: React.FC<PostCardProps> = ({
         </div>
 
         {/* いいねボタンとカウント */}
-        <div className="flex items-center gap-2 pr-2 relative">
-          <div
-            className="relative"
-            onMouseEnter={handleMouseEnter}
-            onMouseLeave={handleMouseLeave}
-          >
-            <button
-              onClick={handleLikeClick}
-              disabled={isLikeLoading}
-              className={`transition-all duration-200 ease-in-out hover:scale-110 disabled:opacity-50 disabled:cursor-not-allowed ${
-                isLiked ? "text-red-500" : "text-gray-400 hover:text-red-400"
-              }`}
-            >
-              {isLiked ? (
-                <AiFillHeart className="w-7 h-7" />
-              ) : (
-                <AiOutlineHeart className="w-7 h-7" />
-              )}
-            </button>
-
-            {/* ツールチップ */}
-            {showTooltip && (
-              <div
-                className="absolute bottom-full right-0 mb-2 w-64 bg-white border border-red-300 rounded-lg shadow-lg p-3 z-50 animate-in fade-in-0 zoom-in-95 duration-200"
-                onMouseEnter={handleTooltipMouseEnter}
-                onMouseLeave={handleTooltipMouseLeave}
-                onClick={handleTooltipClick}
-              >
-                <div className="text-sm font-medium text-gray-800 mb-2">
-                  いいねしたユーザー
-                </div>
-                <div className="text-sm text-gray-600 max-h-20 overflow-hidden">
-                  {isLoadingLikedUsers ? (
-                    <div className="text-gray-400">読み込み中...</div>
-                  ) : likedUsers.length > 0 ? (
-                    <div className="break-words">
-                      <span className="inline-block max-w-full truncate">
-                        {getLikedUsersText()}
-                        {getLikedUsersText().length > 100 && "..."}
-                      </span>
-                    </div>
-                  ) : (
-                    <div className="text-gray-400">まだいいねがありません</div>
-                  )}
-                </div>
-                {/* もっと見るボタン */}
-                {likedUsers.length > 0 && (
-                  <div className="pt-2 border-t border-gray-200 mt-2">
-                    <button
-                      onClick={handleShowMoreClick}
-                      className="text-xs text-blue-500 hover:text-blue-600 font-medium"
-                    >
-                      もっと見る
-                    </button>
-                  </div>
-                )}
-                {/* 矢印 */}
-                <div className="absolute top-full right-4 w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-red-300"></div>
-              </div>
-            )}
-          </div>
-
-          <span
-            className={`text-lg font-medium cursor-pointer hover:underline ${
-              isLiked ? "text-red-500" : "text-gray-500"
-            }`}
-            onClick={handleLikesCountClick}
-          >
-            {likesCount}
-          </span>
+        <div className="flex items-center gap-1 pr-2 relative">
+          <LikeButtonWithTooltip
+            postId={post.id}
+            isLiked={isLiked}
+            likesCount={likesCount}
+            onLikeChange={handleLikeChange}
+            className="h-9 gap-1"
+          />
         </div>
       </div>
-      {/* いいねユーザー一覧モーダル */}
-      <LikedUsersModal
-        isOpen={showLikedUsersModal}
-        onClose={() => setShowLikedUsersModal(false)}
-        postId={post.id}
-        initialUsers={likedUsers}
-      />
     </div>
   );
 };

--- a/front/src/components/ui/button.tsx
+++ b/front/src/components/ui/button.tsx
@@ -18,12 +18,17 @@ const buttonVariants = cva(
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
+        like: "bg-white border border-gray-300 text-gray-500 hover:border-red-300 hover:text-red-400 hover:scale-105 data-[liked=true]:text-red-500 rounded-full shadow-sm",
+        linkSmall:
+          "text-blue-500 hover:text-blue-600 font-medium text-xs p-0 h-auto shadow-none rounded-none bg-transparent hover:bg-transparent",
       },
       size: {
         default: "h-10 px-4 py-2",
         sm: "h-9 rounded-md px-3",
         lg: "h-12 px-8",
         icon: "h-10 w-10",
+        like: "px-4 py-2 text-sm",
+        linkSmall: "p-0 h-auto",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## 概要
投稿詳細ページにいいねボタンを追加しました。

## 実装内容
- [x] いいねボタンの処理を再利用可能なコンポーネント「LikeButtonWithTooltip.tsx」を作成して集約
- [x] PostCardでいいねボタン処理関連を削除
- [x] PostCardと投稿詳細ページでLikeButtonWithTooltipを呼び出していいねボタンの処理を実装

## その他
・いいねした時にメッセージを表示するようにしました。
・投稿詳細ページの編集ボタンの色を白に変更しました。

## issue
#157 