### PR TITLE
【フロント・バック】PostCardにコメントボタンを追加

### DIFF
--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -16,6 +16,7 @@ class ApplicationController < ActionController::API
       typing_play_count: post.typing_play_count,
       likes_count: post.likes_count,
       is_liked: current_api_v1_user ? post.likes.exists?(user_id: current_api_v1_user.id) : false,
+      comments_count: post.comments_count,
       created_at: post.created_at,
       updated_at: post.updated_at
     }

--- a/front/src/app/posts/[id]/page.tsx
+++ b/front/src/app/posts/[id]/page.tsx
@@ -319,6 +319,25 @@ export default function PostDetailPage() {
     }
   };
 
+  // ハッシュによるスクロール処理
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const hash = window.location.hash;
+      if (hash === "#comments") {
+        // 少し遅延してからスクロール（レンダリング完了を待つ）
+        setTimeout(() => {
+          const commentsSection = document.getElementById("comments");
+          if (commentsSection) {
+            commentsSection.scrollIntoView({
+              behavior: "smooth",
+              block: "start",
+            });
+          }
+        }, 200);
+      }
+    }
+  }, []);
+
   if (loading) {
     return (
       <div className="min-h-screen bg-[#f5f7ef] p-4">
@@ -525,7 +544,7 @@ export default function PostDetailPage() {
       {/* Comments and Ranking */}
       <div className="grid md:grid-cols-2 gap-6">
         {/* Comments */}
-        <div className="bg-white rounded-xl p-6 shadow-md">
+        <div id="comments" className="bg-white rounded-xl p-6 shadow-md">
           <h2 className="text-center text-xl font-bold mb-6 text-[#FF8D76]">
             コメント{" "}
             <span className="text-gray-500">({comments.length}件)</span>

--- a/front/src/components/LikeButtonWithTooltip.tsx
+++ b/front/src/components/LikeButtonWithTooltip.tsx
@@ -17,7 +17,7 @@ interface LikeButtonWithTooltipProps {
   onLikeChange: (isLiked: boolean, likesCount: number) => void;
   disabled?: boolean;
   className?: string;
-  size?: "default" | "sm" | "lg" | "icon" | "like" | "linkSmall";
+  size?: "default" | "sm" | "lg" | "icon" | "postIcon" | "linkSmall";
   variant?:
     | "default"
     | "destructive"
@@ -25,8 +25,8 @@ interface LikeButtonWithTooltipProps {
     | "secondary"
     | "ghost"
     | "link"
-    | "like"
-    | "linkSmall";
+    | "linkSmall"
+    | "postIcon";
 }
 
 export function LikeButtonWithTooltip({
@@ -36,8 +36,8 @@ export function LikeButtonWithTooltip({
   onLikeChange,
   disabled = false,
   className = "",
-  size = "like",
-  variant = "like",
+  size = "postIcon",
+  variant = "postIcon",
 }: LikeButtonWithTooltipProps) {
   const { user } = useAuth();
   const [isLikeLoading, setIsLikeLoading] = useState<boolean>(false);

--- a/front/src/components/PostCard.tsx
+++ b/front/src/components/PostCard.tsx
@@ -3,7 +3,12 @@
 import type React from "react";
 import { useState, useEffect } from "react";
 import { useAuth } from "@/contexts/AuthContext";
-import { FiMoreVertical, FiEdit, FiTrash } from "react-icons/fi";
+import {
+  FiMoreVertical,
+  FiEdit,
+  FiTrash,
+  FiMessageCircle,
+} from "react-icons/fi";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -18,6 +23,7 @@ import post_image_def from "/public/post_image_def.png";
 import { useDeletePost } from "@/hooks/useDeletePost";
 import { getUser } from "@/lib/axios";
 import { LikeButtonWithTooltip } from "./LikeButtonWithTooltip";
+import { Button } from "@/components/ui/button";
 
 interface PostCardProps {
   post: Post;
@@ -72,6 +78,14 @@ const PostCard: React.FC<PostCardProps> = ({
     });
   };
 
+  // コメントボタンのクリックハンドラ
+  const handleCommentClick = (event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    // 投稿詳細ページのコメント欄にスクロール
+    window.location.href = `/posts/${post.id}#comments`;
+  };
+
   // いいね状態変更のハンドラ
   const handleLikeChange = (newIsLiked: boolean, newLikesCount: number) => {
     setIsLiked(newIsLiked);
@@ -121,6 +135,13 @@ const PostCard: React.FC<PostCardProps> = ({
     return null;
   };
 
+  // ユーザープロフィール部分をクリックした時のハンドラ
+  const handleUserProfileClick = (event: React.MouseEvent) => {
+    event.preventDefault(); // 親のLinkの遷移を防ぐ
+    event.stopPropagation(); // イベントの伝播を防ぐ
+    window.location.href = getUserProfileLink(); // 直接URLを変更
+  };
+
   // ユーザーのリンク先を決定する関数
   const getUserProfileLink = () => {
     // 投稿者が現在のログインユーザーと同じ場合はマイページへ
@@ -129,13 +150,6 @@ const PostCard: React.FC<PostCardProps> = ({
     }
     // それ以外は通常のユーザーページへ
     return `/users/${post.user_id}`;
-  };
-
-  // ユーザープロフィール部分をクリックした時のハンドラ
-  const handleUserProfileClick = (event: React.MouseEvent) => {
-    event.preventDefault(); // 親のLinkの遷移を防ぐ
-    event.stopPropagation(); // イベントの伝播を防ぐ
-    window.location.href = getUserProfileLink(); // 直接URLを変更
   };
 
   const postUserProfileImageUrl = getPostUserProfileImageUrl();
@@ -217,8 +231,20 @@ const PostCard: React.FC<PostCardProps> = ({
           <span className="text-sm text-gray-500">{getUserName()}</span>
         </div>
 
-        {/* いいねボタンとカウント */}
-        <div className="flex items-center gap-1 pr-2 relative">
+        {/* コメントボタンとカウント、いいねボタンとカウント */}
+        <div className="flex items-center gap-2 pr-2 relative">
+          {/* コメントボタン */}
+          <Button
+            variant="postIcon"
+            size="postIcon"
+            onClick={handleCommentClick}
+            className="h-9 gap-1 data-[liked=true]:bg-blue-50 data-[liked=true]:border-blue-400 data-[liked=true]:text-blue-500 hover:border-blue-300 hover:text-blue-400"
+          >
+            <FiMessageCircle className="w-5 h-5" />
+            <span className="font-medium">{post.comments_count || 0}</span>
+          </Button>
+
+          {/* いいねボタン */}
           <LikeButtonWithTooltip
             postId={post.id}
             isLiked={isLiked}

--- a/front/src/components/ui/button.tsx
+++ b/front/src/components/ui/button.tsx
@@ -18,16 +18,17 @@ const buttonVariants = cva(
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
-        like: "bg-white border border-gray-300 text-gray-500 hover:border-red-300 hover:text-red-400 hover:scale-105 data-[liked=true]:text-red-500 rounded-full shadow-sm",
         linkSmall:
           "text-blue-500 hover:text-blue-600 font-medium text-xs p-0 h-auto shadow-none rounded-none bg-transparent hover:bg-transparent",
+        postIcon:
+          "bg-white border border-gray-300 text-gray-500 hover:border-red-300 hover:text-red-400 hover:scale-105 data-[liked=true]:text-red-500 rounded-full shadow-sm",
       },
       size: {
         default: "h-10 px-4 py-2",
         sm: "h-9 rounded-md px-3",
         lg: "h-12 px-8",
         icon: "h-10 w-10",
-        like: "px-4 py-2 text-sm",
+        postIcon: "px-4 py-2 text-sm",
         linkSmall: "p-0 h-auto",
       },
     },


### PR DESCRIPTION
## 概要
PostCardにコメントボタンを追加し、コメント数がわかるようにしました。
ボタンを押下した場合、投稿詳細ページに遷移してコメント欄までスライドするようにしました。

## 実装内容
- [x] いいねボタンと同じ形でコメントボタンを追加
- [x] コメント数を表示するように処理を実装
- [x] 投稿詳細ページにスライド処理を実装

## その他
application_controller.rbのpost_responseメソッドにコメントカウント用に追加したカラムcomments_countを追加し忘れていたので、追加しました。

## issue
#156 
